### PR TITLE
added table with more response codes

### DIFF
--- a/RESPONSE_CODES.md
+++ b/RESPONSE_CODES.md
@@ -1,4 +1,13 @@
 This file documents response codes as used by the API.
 
-- `RESOURCE_NOT_FOUND`
-  - `GET /v4/clusters/:clusterID/`: Cluster does not exist, or the client is not permitted to know about the cluster
+| response code | description |
+|---------------|-------------|
+| INVALID_CREDENTIALS | This response code indicates the provided credentials are not valid. |
+| PERMISSION_DENIED | This response code indicates the provided credentials are valid, but the requested resource requires other permissions. |
+| RESOURCE_ALREADY_EXISTS | This response code indicates a resource does already exist. |
+| RESOURCE_CREATED | This response code indicates a resource has been created. |
+| RESOURCE_DELETED | This response code indicates a resource has been deleted. |
+| RESOURCE_NOT_FOUND | This response code indicates a resource could not be found. |
+| RESOURCE_UPDATED | This response code indicates a resource has been updated. |
+| UNKNOWN_ATTRIBUTE | This response code indicates the provided data structure contains unexpected fields. |
+| UNKNOWN_ERROR | This response code indicates something went wrong in unpredictable ways. |

--- a/RESPONSE_CODES.md
+++ b/RESPONSE_CODES.md
@@ -1,13 +1,11 @@
 This file documents response codes as used by the API.
 
-| response code | description |
-|---------------|-------------|
-| INVALID_CREDENTIALS | This response code indicates the provided credentials are not valid. |
-| PERMISSION_DENIED | This response code indicates the provided credentials are valid, but the requested resource requires other permissions. |
-| RESOURCE_ALREADY_EXISTS | This response code indicates a resource does already exist. |
-| RESOURCE_CREATED | This response code indicates a resource has been created. |
-| RESOURCE_DELETED | This response code indicates a resource has been deleted. |
-| RESOURCE_NOT_FOUND | This response code indicates a resource could not be found. |
-| RESOURCE_UPDATED | This response code indicates a resource has been updated. |
-| UNKNOWN_ATTRIBUTE | This response code indicates the provided data structure contains unexpected fields. |
-| UNKNOWN_ERROR | This response code indicates something went wrong in unpredictable ways. |
+- `INVALID_CREDENTIALS`: Indicates the provided credentials are not valid.
+- `PERMISSION_DENIED`: Indicates the provided credentials are valid, but the requested resource requires other permissions.
+- `RESOURCE_ALREADY_EXISTS`: Indicates a resource does already exist.
+- `RESOURCE_CREATED`: Indicates a resource has been created.
+- `RESOURCE_DELETED`: Indicates a resource has been deleted.
+- `RESOURCE_NOT_FOUND`: Indicates a resource could not be found.
+- `RESOURCE_UPDATED`: Indicates a resource has been updated.
+- `UNKNOWN_ATTRIBUTE`: Indicates the provided data structure contains unexpected fields.
+- `UNKNOWN_ERROR`: Indicates something went wrong in unpredictable ways.


### PR DESCRIPTION
This PR extends the list of available response codes within the API. Here I took the freedom to suggest another format of documentation. I would say it is good enough to have a table with the actual code and a broad description of what it means. The details should be covered in the corresponding API documentation. So the docs to the response codes is only the about the actual code and its purpose. IMO we do not need to list all routes in the documentation about response codes.