### PR TITLE
Send headers to prevent client-side caching

### DIFF
--- a/docserver/nginx.conf
+++ b/docserver/nginx.conf
@@ -29,5 +29,9 @@ http {
     chunked_transfer_encoding on;
     index index.html;
     root /www;
+
+    # prevent caching
+    expires off;
+    add_header Cache-Control no-cache;
   }
 }


### PR DESCRIPTION
as URLs of YAML resources don't change, I'd rather load them every time to prevent any outdated information from being displayed