### PR TITLE
Adds /v4/ping/ spec

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -146,3 +146,12 @@ definitions:
       client_certificate_data:
         type: string
         description: PEM-encoded certificate
+
+  V4PingResponse:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        type: string
+        description: Ping status

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -146,12 +146,3 @@ definitions:
       client_certificate_data:
         type: string
         description: PEM-encoded certificate
-
-  V4PingResponse:
-    type: object
-    required:
-      - message
-    properties:
-      message:
-        type: string
-        description: Ping status

--- a/spec.yaml
+++ b/spec.yaml
@@ -259,3 +259,30 @@ paths:
                 "id": "02:cc:da:f9:fb:ce:c3:e5:e1:f6:27:d8:43:48:0d:37:4a:ee:b9:67",
                 "ttl_hours": 8640
               }
+
+  /v4/ping/:
+    get:
+      operationId: ping
+      tags:
+        - ping
+      summary: Ping the API connection
+      description: This operation tests the connection to the API, and performs an internal health check.
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: "definitions.yaml#/definitions/V4PingResponse"
+          examples:
+            application/json:
+              {
+                "message": "OK"
+              }
+        "500":
+          description: Error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4PingResponse"
+          examples:
+            application/json:
+              {
+                "message": "FAILED"
+              }

--- a/spec.yaml
+++ b/spec.yaml
@@ -266,23 +266,28 @@ paths:
       tags:
         - ping
       summary: Ping the API connection
-      description: This operation tests the connection to the API, and performs an internal health check.
+      description: |
+        This operation tests the connection to the API, and performs an internal health check.
+
+        Will return 200 when everything is running correctly, and 500 when the internal health check fails, with details of the failure in the message.
       responses:
         "200":
           description: OK
           schema:
-            $ref: "definitions.yaml#/definitions/V4PingResponse"
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
           examples:
             application/json:
               {
-                "message": "OK"
+                "code": "OK",
+                "message": "Everything is OK."
               }
         "500":
           description: Error
           schema:
-            $ref: "definitions.yaml#/definitions/V4PingResponse"
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
           examples:
             application/json:
               {
-                "message": "FAILED"
+                "code": "FAILED",
+                "message": "The gremlins have gotten in!"
               }


### PR DESCRIPTION
Towards https://github.com/giantswarm/api/issues/355
Towards https://github.com/giantswarm/api/issues/280

As an implementation note, this route will ping `userd`, `tokend`, `companyd`, and `cluster-service`'s `/healthz` routes, with a timeout. We'll need to add those endpoints (see https://github.com/giantswarm/giantswarm/issues/1104 and https://github.com/giantswarm/giantswarm/issues/1118).

We can also reuse `/v4/ping/` internally as `/healthz`