### PR TITLE
Add more details to possible cluster error responses

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -3,9 +3,6 @@ definitions:
   # Generic response model
   V4GenericResponse:
     type: object
-    required:
-      - code
-      - message
     properties:
       message:
         type: string

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -9,8 +9,10 @@ definitions:
     properties:
       message:
         type: string
+        description: "A human readable message"
       code:
         type: string
+        description: "One of the response codes from: https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md"
 
   # Request to create a new cluster
   V4AddClusterRequest:

--- a/details/RESPONSE_CODES.md
+++ b/details/RESPONSE_CODES.md
@@ -6,9 +6,11 @@ Error messages and standard responses, like after creation of a resource, contai
 - `PERMISSION_DENIED`: Indicates the provided credentials are valid, but the requested resource requires other permissions.
 - `RESOURCE_ALREADY_EXISTS`: Indicates a resource does already exist.
 - `RESOURCE_CREATED`: Indicates a resource has been created.
+- `RESOURCE_DELETION_STARTED`: Indicates a resource will be deleted.
 - `RESOURCE_DELETED`: Indicates a resource has been deleted.
 - `RESOURCE_DELETION_STARTED`: Deleting the resource is in progress.
 - `RESOURCE_NOT_FOUND`: Indicates a resource could not be found.
 - `RESOURCE_UPDATED`: Indicates a resource has been updated.
+- `IMMUTABLE_ATTRIBUTE`: Indicates the provided data structure contains fields you are not allowed to edit.
 - `UNKNOWN_ATTRIBUTE`: Indicates the provided data structure contains unexpected fields.
 - `UNKNOWN_ERROR`: Indicates something went wrong in unpredictable ways.

--- a/spec.yaml
+++ b/spec.yaml
@@ -99,6 +99,10 @@ paths:
                 "code": "PERMISSION_DENIED",
                 "message": "The requested resource cannot be accessed using the provided permission rights. Please make sure you are a member of the organization you set in the 'owner' field."
               }
+        default:
+          description: error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/clusters/{cluster_id}/:
     get:
@@ -161,6 +165,10 @@ paths:
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
+        default:
+          description: error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
     patch:
       operationId: modifyCluster
       tags:
@@ -189,6 +197,10 @@ paths:
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
+        default:
+          description: error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
     delete:
       operationId: deleteCluster
       tags:
@@ -223,6 +235,10 @@ paths:
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
+        default:
+          description: error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/clusters/{cluster_id}/key-pairs/:
     get:
@@ -242,7 +258,7 @@ paths:
           schema:
             $ref: "definitions.yaml#/definitions/V4GetKeyPairsResponse"
         default:
-          description: Error
+          description: error
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
     post:

--- a/spec.yaml
+++ b/spec.yaml
@@ -159,7 +159,7 @@ paths:
             application/json:
               {
                 "code": "RESOURCE_NOT_FOUND",
-                "message": "The cluster could not be found."
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
     patch:
       operationId: modifyCluster
@@ -187,7 +187,7 @@ paths:
             application/json:
               {
                 "code": "RESOURCE_NOT_FOUND",
-                "message": "The cluster could not be found."
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
     delete:
       operationId: deleteCluster
@@ -221,7 +221,7 @@ paths:
             application/json:
               {
                 "code": "RESOURCE_NOT_FOUND",
-                "message": "The cluster could not be found."
+                "message": "The cluster with ID 'wqtlq' could not be found, or perhaps you do not have access to it. Please make sure the cluster ID is correct, and that you are a member of the organization that it belongs to."
               }
 
   /v4/clusters/{cluster_id}/key-pairs/:

--- a/spec.yaml
+++ b/spec.yaml
@@ -90,7 +90,7 @@ paths:
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
         "401":
-          description: Permission Denied
+          description: Permission denied
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
           examples:

--- a/spec.yaml
+++ b/spec.yaml
@@ -89,10 +89,16 @@ paths:
                 "code": "RESOURCE_CREATED",
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
-        default:
-          description: Error
+        "401":
+          description: Permission Denied
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "PERMISSION_DENIED",
+                "message": "The requested resource cannot be accessed using the provided permission rights. Please make sure you are a member of the organization you set in the 'owner' field."
+              }
 
   /v4/clusters/{cluster_id}/:
     get:
@@ -145,10 +151,16 @@ paths:
                   }
                 ]
               }
-        default:
-          description: Error
+        "404":
+          description: Cluster not found
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster could not be found."
+              }
     patch:
       operationId: modifyCluster
       tags:
@@ -167,10 +179,16 @@ paths:
           description: Cluster modified
           schema:
             $ref: 'definitions.yaml#/definitions/V4ClusterDetailsResponse'
-        default:
-          description: Error
+        "404":
+          description: Cluster not found
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster could not be found."
+              }
     delete:
       operationId: deleteCluster
       tags:
@@ -195,10 +213,16 @@ paths:
                 "code": "RESOURCE_DELETION_STARTED",
                 "message": "The cluster with ID 'wqtlq' is being deleted"
               }
-        default:
-          description: Error
+        "404":
+          description: Cluster not found
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The cluster could not be found."
+              }
 
   /v4/clusters/{cluster_id}/key-pairs/:
     get:

--- a/spec.yaml
+++ b/spec.yaml
@@ -211,7 +211,7 @@ paths:
             application/json:
               {
                 "code": "RESOURCE_DELETION_STARTED",
-                "message": "The cluster with ID 'wqtlq' is being deleted"
+                "message": "The cluster with ID 'wqtlq' is being deleted."
               }
         "404":
           description: Cluster not found


### PR DESCRIPTION
This specifies what kind of errors our Cluster endpoints will return, as this is not yet specified.

In a nutshell: I think the API should return 401 when the user tries to create a cluster but the organization does not exist or the user is not a member of the organization. (As is already implemented)

However, for the GET, DELETE, and PATCH requests I would expect the API to return a 404, even when the cluster actually exists, but the user simply can't act on it because he is not a member of the organization.

The reasoning behind this difference is that in the 'CREATE' case, we are not acting on something that exists yet, so it doesn't make sense to return a 404. 

In the case of GET, DELETE, and PATCH, the user is providing a `cluster_id` and wants to act on something that he thinks is there. So when he can't act on it because it doesn't exist, or because he shouldn't have access to it, we should return a 404. We return a 404 instead of a 401 in the 'he shouldn't have access it' case because we want to avoid revealing any information we don't need to. If we we're to return a 401, we'd reveal that the cluster ID is in use.

------------------------------

**POST** `/v4/clusters/` will return `401` when the user tries to create a cluster for an organization that he is not a member of. (Already implemented)

**POST** `/v4/clusters/` will return `401` when the user tries to create a cluster for an organization that does not exist. (Already implemented)

**GET** `/v4/clusters/{cluster-id}` will return `404` when the cluster doesn't exist

**GET** `/v4/clusters/{cluster-id}` will return `404` when the cluster exists but the user is not a member of the organization the cluster belongs to.

**DELETE** `/v4/clusters/{cluster-id}` will return `404` when the cluster doesn't exist

**DELETE** `/v4/clusters/{cluster-id}` will return `404` when the cluster exists but the user is not a 
member of the organization the cluster belongs to.

**PATCH** `/v4/clusters/{cluster-id}` will return `404` when the cluster doesn't exist

**PATCH** `/v4/clusters/{cluster-id}` will return `404` when the cluster exists but the user is not a 
member of the organization the cluster belongs to.