### PR TITLE
Fixes in YAML structure; Adding validation tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+spec-tmp.yaml
+spec-tmp.yamle

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+spec-tmp.yaml:
+	# Create concatenated spec file
+	cat spec.yaml >> spec-tmp.yaml
+	echo "" >> spec-tmp.yaml
+	cat definitions.yaml >> spec-tmp.yaml
+	echo "" >> spec-tmp.yaml
+	cat parameters.yaml >> spec-tmp.yaml
+	# fix references
+	sed -ie 's/definitions\.yaml//g' spec-tmp.yaml
+	sed -ie 's/parameters\.yaml//g' spec-tmp.yaml
+
+validate: spec-tmp.yaml
+	# For local validation
+	yamllint -c ./yamllint/config.yaml ./spec.yaml ./definitions.yaml ./parameters.yaml ./responses.yaml
+	docker run --rm -it \
+		-v $(shell pwd):/code/yaml \
+		jimschubert/swagger-codegen-cli generate \
+		--input-spec /code/yaml/spec-tmp.yaml \
+		--lang swagger --output /tmp/
+	# remove temp files
+	rm -f spec-tmp.yaml
+	rm -f spec-tmp.yamle
+
+test: spec-tmp.yaml
+	# For CircleCI (--rm=false required)
+	docker run --rm=false -it \
+		-v $(shell pwd):/code/yaml \
+		jimschubert/swagger-codegen-cli generate \
+		--input-spec /code/yaml/spec-tmp.yaml \
+		--lang swagger --output /tmp/
+	# remove temp files
+	rm -f spec-tmp.yaml
+	rm -f spec-tmp.yamle

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ validate: spec-tmp.yaml
 
 test: spec-tmp.yaml
 	# For CircleCI (--rm=false required)
+	yamllint -c ./yamllint/config.yaml ./spec.yaml ./definitions.yaml ./parameters.yaml ./responses.yaml
 	docker run --rm=false -it \
 		-v $(shell pwd):/code/yaml \
 		jimschubert/swagger-codegen-cli generate \

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Please obey these conventions when editing the spec YAML files:
 - 2 spaces per indentation level
 - avoid quotes where possible
 
+### Validation
+
+Run `make validate` to check the specification YAML integrity.
+
+This requires `yamllint` to be available. To install it, either do `sudo pip install yamllint` or create the following alias:
+
+```
+alias yamllint="docker run --rm -ti -v $(pwd):/workdir giantswarm/yamllint"
+```
+
 ### Rendering an HTML documentation preview
 
 Use this command from the root directory of your clone of this repo:

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,14 @@ machine:
     services:
         - docker
 
+dependencies:
+    pre:
+        - sudo apt-get update; sudo apt-get install -y python-pip
+        - sudo pip install yamllint
+
 test:
+    pre:
+        - make test
     override:
         # build the docserver docker image
         - docker build -t registry.giantswarm.io/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-docserver:$CIRCLE_SHA1 -f docserver/Dockerfile .

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -4,8 +4,8 @@ definitions:
   V4GenericResponse:
     type: object
     required:
-     - code
-     - message
+      - code
+      - message
     properties:
       message:
         type: string

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -1,34 +1,8 @@
-ClusterIdPathParameter:
-  name: cluster_id
-  in: path
-  required: true
-  type: string
-  description: Cluster ID
+parameters:
 
-DomainPathParameter:
-  name: domain
-  in: path
-  required: true
-  type: string
-  description: Domain name
-
-InvoiceNumberPathParameter:
-  name: invoice_number
-  in: path
-  required: true
-  type: string
-  description: Invoice ID
-
-OrganizationIdPathParameter:
-  name: organization_id
-  in: path
-  required: true
-  type: string
-  description: Organization ID
-
-UserIdPathParameter:
-  name: user_id
-  in: path
-  required: true
-  type: string
-  description: Unique user ID
+  ClusterIdPathParameter:
+    name: cluster_id
+    in: path
+    required: true
+    type: string
+    description: Cluster ID

--- a/spec.yaml
+++ b/spec.yaml
@@ -100,7 +100,7 @@ paths:
       tags:
         - clusters
       parameters:
-        - $ref: 'parameters.yaml#/ClusterIdPathParameter'
+        - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
       summary: Get cluster details
       description: |
         This operation allows to obtain all available details on a particular cluster.
@@ -154,7 +154,7 @@ paths:
       tags:
         - clusters
       parameters:
-        - $ref: 'parameters.yaml#/ClusterIdPathParameter'
+        - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
       summary: Modify cluster
       description: |
         This operation allows to modify an existing cluster.
@@ -176,7 +176,7 @@ paths:
       tags:
         - clusters
       parameters:
-        - $ref: 'parameters.yaml#/ClusterIdPathParameter'
+        - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
       summary: Delete cluster
       description: |
         This operation allows to delete a cluster.
@@ -211,7 +211,7 @@ paths:
 
         The individual array items contain metadata on the key pairs, but neither the key nor the certificate. These can only be obtained upon creation, using the [addKeypair](#operation/addKeyPair) operation.
       parameters:
-        - $ref: 'parameters.yaml#/ClusterIdPathParameter'
+        - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
       responses:
         "200":
           description: Key pairs
@@ -227,7 +227,7 @@ paths:
         - key pairs
       summary: Create key pair
       parameters:
-        - $ref: 'parameters.yaml#/ClusterIdPathParameter'
+        - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
         - name: body
           in: body
           required: true

--- a/yamllint/config.yaml
+++ b/yamllint/config.yaml
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  # don't fail if line is longer than 80 characters
+  line-length:
+    max: 80
+    level: warning
+
+  # don't warn about missing "---" at beginning
+  document-start: disable


### PR DESCRIPTION
- `parameters.yaml` was missing a parent key at the beginning of the file, which has been added. References were updated. Also, unused items were deleted.
- To validate the concatenated spec YAML, a Makefile with `make validate` (for local use) and `make test` (for CircleCI use) has been introduced.