### PR TITLE
Specify that admin users are able to delete any orgs

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -348,7 +348,7 @@ paths:
       summary: Delete an organization
       description: |
         This operation allows a user to delete an organization that they are a member of.
-        Admin users, however, are able to delete organizations they are not a member of.
+        Admin users can delete any organization.
       parameters:
         - $ref: 'parameters.yaml#/parameters/OrganizationIdPathParameter'
       responses:

--- a/spec.yaml
+++ b/spec.yaml
@@ -347,7 +347,8 @@ paths:
         - organizations
       summary: Delete an organization
       description: |
-        This operation allows a user to delete an organization.
+        This operation allows a user to delete an organization that they are a member of.
+        Admin users, however, are able to delete organizations they are not a member of.
       parameters:
         - $ref: 'parameters.yaml#/parameters/OrganizationIdPathParameter'
       responses:


### PR DESCRIPTION
The admin user hasn't been given much love in v4 yet. For organization delete, the admin should be able to delete any org. This PR adds that 'rule' the spec.

There is no need to talk about the admin user in the create org part, because creating an org should behave the same way for normal users as well as admin users.