### PR TITLE
Spec for PATCH /v4/organizations/:org-id/

### DIFF
--- a/details/RESPONSE_CODES.md
+++ b/details/RESPONSE_CODES.md
@@ -13,4 +13,5 @@ Error messages and standard responses, like after creation of a resource, contai
 - `RESOURCE_UPDATED`: Indicates a resource has been updated.
 - `IMMUTABLE_ATTRIBUTE`: Indicates the provided data structure contains fields you are not allowed to edit.
 - `UNKNOWN_ATTRIBUTE`: Indicates the provided data structure contains unexpected fields.
+- `INVALID_INPUT`: Indicates that the user provided input that is not valid in some way.
 - `UNKNOWN_ERROR`: Indicates something went wrong in unpredictable ways.

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -13,7 +13,7 @@ parameters:
     required: true
     type: string
     description: |
-        An ID for the organization to be created is the only required parameter.
+        An ID for the organization.
         This ID must be unique and match this regular expression: ^[a-z0-9_]{4,30}$
 
   XIdempotencyKeyHeader:

--- a/spec.yaml
+++ b/spec.yaml
@@ -452,6 +452,17 @@ paths:
         - organizations
       parameters:
         - $ref: 'parameters.yaml#/parameters/OrganizationIdPathParameter'
+        - name: body
+          in: body
+          required: true
+          schema:
+            properties:
+              members:
+                type: array
+                description: List of members that belong to this organization
+                items:
+                  $ref: 'definitions.yaml#/definitions/V4OrganizationMember'
+
       summary: Modify organization
       description: |
         This operation allows you to modify an existing organization. You must be
@@ -474,6 +485,16 @@ paths:
           description: Organization modified
           schema:
             $ref: 'definitions.yaml#/definitions/V4Organization'
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The organization could not be modified. (request is invalid for various reasons: 'asdf@' is not a valid email address, 'bob@example.com' does not exist)"
+              }
         "401":
           description: Permission denied
           schema:
@@ -493,16 +514,6 @@ paths:
               {
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The organization could not be modified. (not found: the organization with id 'acme' could not be found)"
-              }
-        "400":
-          description: Bad input
-          schema:
-            $ref: "definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "INVALID_INPUT",
-                "message": "The organization could not be modified. (request is invalid for various reasons: 'asdf@' is not a valid email address, 'bob@example.com' does not exist)"
               }
         default:
           description: error

--- a/spec.yaml
+++ b/spec.yaml
@@ -470,7 +470,7 @@ paths:
 
         The following attributes can be modified:
 
-        - `members`: By modifying the array of members, members can be added or removed from the organization
+        - `members`: By modifying the array of members, members can be added to or removed from the organization
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
         Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
@@ -479,7 +479,7 @@ paths:
         means every member you attempt to add to the organization must actually
         exist in the system. If any member you attempt to add is invalid, the entire
         patch operation will fail, no members will be added or removed, and an error message
-        will explaining which members in your request are invalid.
+        will explain which members in your request are invalid.
       responses:
         "200":
           description: Organization modified

--- a/spec.yaml
+++ b/spec.yaml
@@ -446,6 +446,68 @@ paths:
           description: Error
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+    patch:
+      operationId: modifyOrganization
+      tags:
+        - organizations
+      parameters:
+        - $ref: 'parameters.yaml#/parameters/OrganizationIdPathParameter'
+      summary: Modify organization
+      description: |
+        This operation allows you to modify an existing organization. You must be
+        a member of the organization or an admin in order to use this endpoint.
+
+        The following attributes can be modified:
+
+        - `members`: By modifying the array of members, members can be added or removed from the organization
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+
+        The full request must be valid before it will be executed, currently this
+        means every member you attempt to add to the organization must actually
+        exist in the system. If any member you attempt to add is invalid, the entire
+        patch operation will fail, no members will be added or removed, and an error message
+        will explaining which members in your request are invalid.
+      responses:
+        "200":
+          description: Organization modified
+          schema:
+            $ref: 'definitions.yaml#/definitions/V4Organization'
+        "401":
+          description: Permission denied
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "PERMISSION_DENIED",
+                "message": "The organization could not be modified. (unauthorized: you must be a member of 'acme')"
+              }
+        "404":
+          description: Organization not found
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The organization could not be modified. (not found: the organization with id 'acme' could not be found)"
+              }
+        "400":
+          description: Bad input
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The organization could not be modified. (request is invalid for various reasons: 'asdf@' is not a valid email address, 'bob@example.com' does not exist)"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
     delete:
       operationId: deleteOrganization
       tags:

--- a/spec.yaml
+++ b/spec.yaml
@@ -493,7 +493,7 @@ paths:
             application/json:
               {
                 "code": "INVALID_INPUT",
-                "message": "The organization could not be modified. (request is invalid for various reasons: 'asdf@' is not a valid email address, 'bob@example.com' does not exist)"
+                "message": "The organization could not be modified. (invalid input: user 'invalid-email' does not exist or is invalid)"
               }
         "401":
           description: Permission denied


### PR DESCRIPTION
Discussed here: https://github.com/giantswarm/api-spec/issues/29

I think there are a few more things to discuss though:

**1. What to do when the request is invalid?**
Currently I have specced it so that the entire patch operation fails. So if a member is being added that doesn't exist, or has an invalid email address, no  add/remove of members will happen at all, even if there might be other members in the patch request that are valid. Do we agree this is the right way to go about it? An alternative would be to just ignore invalid input.

**2. I think we need a new giant swarm response code:**
We have `UNKNOWN_ATTRIBUTE` and `IMMUTABLE_ATTRIBUTE` but that doesn't really match with what is going wrong here. What do you think of `INVALID_INPUT` with a http error code of `400` ?

ping @marians 