### PR TITLE
Spec for GET /v4/clusters/

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -6,10 +6,10 @@ definitions:
     properties:
       message:
         type: string
-        description: "A human readable message"
+        description: A human readable message
       code:
         type: string
-        description: "One of the response codes from: https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md"
+        description: A machine readable [response code](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) like e. g. `INVALID_CREDENTIALS`
 
   # Request to create a new cluster
   V4AddClusterRequest:
@@ -195,3 +195,20 @@ definitions:
       expiry:
         type: string
         description: The date and time when this account will expire
+
+  # A cluster array item, as return by getClusters
+  V4ClusterListItem:
+    type: object
+    properties:
+      id:
+        type: string
+        description: Unique cluster identifier
+      create_date:
+        type: string
+        description: Date/time of cluster creation
+      name:
+        type: string
+        description: Cluster name
+      owner:
+        type: string
+        description: Name of the organization owning the cluster

--- a/spec.yaml
+++ b/spec.yaml
@@ -115,7 +115,7 @@ paths:
         - clusters
       summary: Get clusters
       description: |
-        This operation allows to fetch a list of clusters.
+        This operation fetches a list of clusters.
 
         The result depends on the permissions of the user.
         A normal user will get all the clusters the user has access

--- a/spec.yaml
+++ b/spec.yaml
@@ -109,6 +109,51 @@ paths:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/clusters/:
+    get:
+      operationId: getClusters
+      tags:
+        - clusters
+      summary: Get clusters
+      description: |
+        This operation allows to fetch a list of clusters.
+
+        The result depends on the permisisons of the user.
+        A normal user will get in return all the clusters the user has access
+        to, via organization membership.
+        A user with admin permission will receive a list of all existing
+        clusters.
+
+        The result array items are sparse representations of the cluster objects.
+        To fetch more details on a cluster, use the [getCluster](#operation/getCluster)
+        operation.
+      parameters:
+      responses:
+        "200":
+          description: Success
+          schema:
+            type: array
+            items:
+              $ref: "definitions.yaml#/definitions/V4ClusterListItem"
+          examples:
+            application/json:
+              [
+                {
+                  "id": "g8s3o",
+                  "create_date": "2017-06-08T12:31:47.215Z",
+                  "name": "Staging Cluster",
+                  "owner": "acme"
+                },
+                {
+                  "id": "3dkr6",
+                  "create_date": "2017-05-22T13:58:02.024Z",
+                  "name": "Test Cluster",
+                  "owner": "testorg"
+                }
+              ]
+        default:
+          description: Error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
     post:
       operationId: addCluster
       tags:

--- a/spec.yaml
+++ b/spec.yaml
@@ -118,7 +118,7 @@ paths:
         This operation allows to fetch a list of clusters.
 
         The result depends on the permissions of the user.
-        A normal user will get in return all the clusters the user has access
+        A normal user will get all the clusters the user has access
         to, via organization membership.
         A user with admin permission will receive a list of all existing
         clusters.

--- a/spec.yaml
+++ b/spec.yaml
@@ -117,7 +117,7 @@ paths:
       description: |
         This operation allows to fetch a list of clusters.
 
-        The result depends on the permisisons of the user.
+        The result depends on the permissions of the user.
         A normal user will get in return all the clusters the user has access
         to, via organization membership.
         A user with admin permission will receive a list of all existing


### PR DESCRIPTION
This adds the spec for `GET /v4/clusters/`.

Minor changed in the definition of `V4GenericResponse` to improve the readability in the rendered HTML docs.

**To be merged after implementation**