### PR TITLE
Spec for scaling clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 spec-tmp.yaml
 spec-tmp.yamle
 kubernetes/secrets.yaml

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -71,7 +71,7 @@ definitions:
         properties:
           instance_type:
             type: string
-            description: EC2 instance type name
+            description: EC2 instance type name. Must be the same for all worker nodes of a cluster.
       memory:
         type: object
         properties:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -32,6 +32,20 @@ definitions:
         items:
           $ref: '#/definitions/V4NodeDefinition'
 
+  V4ModifyClusterRequest:
+    type: object
+    required: []
+    description: Request body for cluster modification
+    properties:
+      owner:
+        type: string
+        description: Name of the organization owning the cluster
+      workers:
+        type: array
+        description: Worker node array
+        items:
+          $ref: '#/definitions/V4NodeDefinition'
+
   # Details on existing cluster
   V4ClusterDetailsResponse:
     type: object

--- a/details/CLUSTER_DEFINITION.md
+++ b/details/CLUSTER_DEFINITION.md
@@ -65,15 +65,15 @@ This example here shows a cluster definition in JSON format, as it may be submit
               "instance_type": "m3.large"
             },
             "labels": {
-                "nodetype": "standard"
+                "nickname": "first node"
             }
         },
         {
             "aws": {
-              "instance_type": "r3.xlarge"
+              "instance_type": "m3.large"
             },
             "labels": {
-                "nodetype": "big-ram"
+                "nickname": "second node"
             }
         }
     ]
@@ -103,22 +103,22 @@ After creation using the definition above, the code below shows the completed cl
                 "beta.kubernetes.io/os": "linux",
                 "ip": "10.3.11.2",
                 "kubernetes.io/hostname": "worker-1.wqtlq.example.com",
-                "nodetype": "standard"
+                "nickname": "first node"
             }
         },
         {
             "aws": {
-              "instance_type": "r3.xlarge"
+              "instance_type": "m3.large"
             },
-            "memory": {"size_gb": 30.5},
-            "storage": {"size_gb": 80},
-            "cpu": {"cores": 4},
+            "memory": {"size_gb": 7.5},
+            "storage": {"size_gb": 32},
+            "cpu": {"cores": 2},
             "labels": {
                 "beta.kubernetes.io/arch": "amd64",
                 "beta.kubernetes.io/os": "linux",
                 "ip": "10.3.62.2",
                 "kubernetes.io/hostname": "worker-2.wqtlq.example.com",
-                "nodetype": "big-ram"
+                "nickname": "second node"
             }
         }
     ]
@@ -134,7 +134,7 @@ After creation using the definition above, the code below shows the completed cl
 - `kubernetes_version`: Kubernetes version of the cluster. The string reported here may also contain additional details and thus may not be machine-interpretable.
 - `owner`: Name of the organization owning the cluster.
 - `workers`: Array of worker definition objects. Each array item represents one worker node. In order to create a cluster with three worker nodes, this array MUST have three items, even if all worker share the same configuration.
-- `workers[n].aws.instance_type`: Name of the EC2 instance type to use for the worker node. For clusters running on AWS, this attribute is required on cluster creation.
+- `workers[n].aws.instance_type`: Name of the EC2 instance type to use for the worker node. For clusters running on AWS, this attribute is required on cluster creation and must have the same value for all worker nodes of the cluster.
 - `workers[n].memory`: Memory definition object. This object can currently contain only one attribute `size_gb`, which indicates the RAM size in Gigabytes as an integer. For clusters running on AWS, this attribute is ignored on cluster creation.
 - `workers[n].storage`: Storage definition object. Storage here refers to the local disk storage of a worker node. The definition object can currently contain only one attribute `size_gb`, which indicates the local storage size in Gigabytes as an integer. For clusters running on AWS, this attribute is ignored on cluster creation.
 - `workers[n].cpu`: CPU definition object. This object may (only) contain the attribute `cores`, indicating the number of CPU cores for the given worker node. For clusters running on AWS, this attribute is ignored on cluster creation.

--- a/spec.yaml
+++ b/spec.yaml
@@ -328,7 +328,6 @@ paths:
         when submitting a PATCH request, you ensure that the right instance type
         is used automatically.
 
-        Note for clusters on AWS: When adding worker nodes to a cluster, they must use the same `instance_type` as the existing workers.
       responses:
         "200":
           description: Cluster modified

--- a/spec.yaml
+++ b/spec.yaml
@@ -241,19 +241,92 @@ paths:
       tags:
         - clusters
       parameters:
+        - name: body
+          in: body
+          required: true
+          description: Merge-patch body
+          schema:
+            $ref: 'definitions.yaml#/definitions/V4ModifyClusterRequest'
         - $ref: 'parameters.yaml#/parameters/ClusterIdPathParameter'
       summary: Modify cluster
       description: |
         This operation allows to modify an existing cluster.
 
+        A cluster modification is performed by submitting a `PATCH` request
+        to the cluster resource (as described in the
+        [addCluster](#operation/addCluster) and [getCluster](#operation/getCluster))
+        in form of a [JSON Patch Merge
+        (RFC 7386)](https://tools.ietf.org/html/rfc7386). This means, only the
+        attributes to be modified have to be contained in the request body.
+
         The following attributes can be modified:
 
-        - `owner`: Given that the requesting user has admin permissions, this can be used to change a cluster's ownership.
-        - `workers`: By modifying the array of workers, nodes can be added to increase the cluster's capacity.
-        When adding nodes, the node definition has to conform to the specification as detailed in the [cluster creation](#operation/addCluster) operation.
+        - `owner`: Changing the owner organization name means to change cluster
+        ownership from one organization to another. The user performing the
+        request has to be a member of both organizations.
 
-        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
-        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+        - `workers`: By modifying the array of workers, nodes can be added to
+        increase the cluster's capacity. See details below.
+
+        ### Adding and Removing Worker Nodes (Scaling)
+
+        Adding worker nodes to a cluster or removing worker nodes from a cluster
+        works by submitting the `workers` attribute, which contains a (sparse)
+        array of worker node defintions.
+
+        _Sparse_ here means that all configuration details are optional. In the
+        case that worker nodes are added to a cluster, wherever a configuration
+        detail is missing, defaults will be applied. See
+        [Creating a cluster](#operation/addCluster) for details.
+
+        When modifying the cluster resource, you describe the desired state.
+        For scaling, this means that the worker node array submitted must
+        contain as many elements as the cluster should have worker nodes.
+        If your cluster currently has five nodes and you submit a workers
+        array with four elements, this means that one worker node will be removed.
+        If your submitted workers array has six elements, this means one will
+        be added.
+
+        As an example, this request body could be used to scale a cluster to
+        three worker nodes:
+
+        ```json
+        {
+          "workers": [{}, {}, {}]
+        }
+        ```
+
+        If the scaled cluster had four worker nodes before, one would be removed.
+        If it had two worker nodes before, one with default settings would be
+        added.
+
+        To add a worker with specific configuration to a KVM-based cluster that
+        currently has three nodes, a request body like the following would work:
+
+        ```json
+        {
+          "workers": [
+            {},
+            {},
+            {},
+            {
+              "cpu": {"cores": 4},
+              "memory": {"size_gb": 10},
+              "storage": {"size_gb": 80}
+            }
+          ]
+        }
+        ```
+
+        ### Limitations
+
+        - As of now, existing worker nodes cannot be modified.
+        - When removing nodes (scaling down), it is not possible to determine
+        which nodes will be removed.
+        - On AWS based clusters, all worker nodes must use the same EC2 instance
+        type (`instance_type` node attribute). By not setting an `instance_type`
+        when submitting a PATCH request, you ensure that the right instance type
+        is used automatically.
 
         Note for clusters on AWS: When adding worker nodes to a cluster, they must use the same `instance_type` as the existing workers.
       responses:

--- a/spec.yaml
+++ b/spec.yaml
@@ -244,7 +244,10 @@ paths:
       description: |
         This operation allows to modify an existing cluster.
 
-        __Note:__ This operation currently requires special permission. Also, currently only the `owner` attribute can be changed.
+        The following attributes can be modified:
+
+        - `owner`: Given that the requesting user has admin permissions, this can be used to change a cluster's ownership.
+        - `workers`: By modifying the array of workers, nodes can be added or removed to scale the cluster's capacity. When adding nodes, the node definition has to conform the specification as detailed in the [cluster creation](#operation/addCluster) operation.
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard. Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
       responses:

--- a/spec.yaml
+++ b/spec.yaml
@@ -250,7 +250,7 @@ paths:
 
         - `owner`: Given that the requesting user has admin permissions, this can be used to change a cluster's ownership.
         - `workers`: By modifying the array of workers, nodes can be added or removed to scale the cluster's capacity.
-        When adding nodes, the node definition has to conform the specification as detailed in the [cluster creation](#operation/addCluster) operation.
+        When adding nodes, the node definition has to conform to the specification as detailed in the [cluster creation](#operation/addCluster) operation.
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
         Requests have to be sent with the `Content-Type: application/merge-patch+json` header.

--- a/spec.yaml
+++ b/spec.yaml
@@ -300,26 +300,10 @@ paths:
         If it had two worker nodes before, one with default settings would be
         added.
 
-        To add a worker with specific configuration to a KVM-based cluster that
-        currently has three nodes, a request body like the following would work:
-
-        ```json
-        {
-          "workers": [
-            {},
-            {},
-            {},
-            {
-              "cpu": {"cores": 4},
-              "memory": {"size_gb": 10},
-              "storage": {"size_gb": 80}
-            }
-          ]
-        }
-        ```
-
         ### Limitations
 
+        - Adding and removing worker nodes is currently only supported on
+        AWS-based installations, not on KVM-based ones.
         - As of now, existing worker nodes cannot be modified.
         - When removing nodes (scaling down), it is not possible to determine
         which nodes will be removed.

--- a/spec.yaml
+++ b/spec.yaml
@@ -129,6 +129,8 @@ paths:
 
         ```"workers": [{}, {}, {}]```
 
+        For clusters on AWS, note that all worker nodes must use the same instance type.
+
         This operation supports [idempotency](#idempotency) via the `X-Idempotency-Key` header.
 
       parameters:
@@ -247,9 +249,13 @@ paths:
         The following attributes can be modified:
 
         - `owner`: Given that the requesting user has admin permissions, this can be used to change a cluster's ownership.
-        - `workers`: By modifying the array of workers, nodes can be added or removed to scale the cluster's capacity. When adding nodes, the node definition has to conform the specification as detailed in the [cluster creation](#operation/addCluster) operation.
+        - `workers`: By modifying the array of workers, nodes can be added or removed to scale the cluster's capacity.
+        When adding nodes, the node definition has to conform the specification as detailed in the [cluster creation](#operation/addCluster) operation.
 
-        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard. Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+
+        Note for clusters on AWS: When adding worker nodes to a cluster, they must use the same `instance_type` as the existing workers.
       responses:
         "200":
           description: Cluster modified

--- a/spec.yaml
+++ b/spec.yaml
@@ -249,7 +249,7 @@ paths:
         The following attributes can be modified:
 
         - `owner`: Given that the requesting user has admin permissions, this can be used to change a cluster's ownership.
-        - `workers`: By modifying the array of workers, nodes can be added or removed to scale the cluster's capacity.
+        - `workers`: By modifying the array of workers, nodes can be added to increase the cluster's capacity.
         When adding nodes, the node definition has to conform to the specification as detailed in the [cluster creation](#operation/addCluster) operation.
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.


### PR DESCRIPTION
**To be merged when implemented**

This PR applies the same changes as https://github.com/giantswarm/api-spec/pull/27, but this time, it should remain unmerged until ready.

TODO

- [x] Inform that scaling is not available on KVM based clusters.
