### PR TITLE
Fix type, add charset meta tag

### DIFF
--- a/docserver/index.html
+++ b/docserver/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title>Giant Swarm API</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>

--- a/spec.yaml
+++ b/spec.yaml
@@ -652,6 +652,7 @@ paths:
           in: body
           required: true
           schema:
+            type: object
             properties:
               members:
                 type: array


### PR DESCRIPTION
We had a parser error in our spec. It got only picked up by redoc, the web renderer.

![image](https://user-images.githubusercontent.com/273727/28960730-15d8fc94-7900-11e7-8f48-5dbb703599cb.png)
