### PR TITLE
Spec creating users

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -388,3 +388,16 @@ definitions:
             version:
               type: string
               description: Version number of the component
+
+  V4CreateUserRequest:
+    type: object
+    required:
+      - password
+    description: Request model for creating a new user
+    properties:
+      password:
+        type: string
+        description: A Base64 encoded password
+      expiry:
+        type: string
+        description: The date and time when this account will expire

--- a/spec.yaml
+++ b/spec.yaml
@@ -218,7 +218,7 @@ paths:
             application/json:
               {
                 "code": "RESOURCE_ALREADY_EXISTS",
-                "message": "The user could not be created. (invalid input: email 'bob@example.com' already exists.)"
+                "message": "The user could not be created. (invalid input: email 'bob@example.com' already exists)"
               }
         "401":
           description: Permission denied

--- a/spec.yaml
+++ b/spec.yaml
@@ -183,6 +183,58 @@ paths:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/users/{email}/:
+    put:
+      operationId: createUser
+      parameters:
+        - $ref: 'parameters.yaml#/parameters/UserEmailPathParameter'
+
+        - name: body
+          in: body
+          required: true
+          description: Merge-patch body
+          schema:
+            $ref: 'definitions.yaml#/definitions/V4CreateUserRequest'
+      tags:
+        - users
+      summary: Create user
+      description: |
+        Creates a users in the system. Currently this endpoint is only available to users with admin permissions.
+      responses:
+        "200":
+          description: User created
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "The user with email 'bob@example.com' has been created."
+              }
+        "400":
+          description: User already exists
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "The user could not be created. (invalid input: email 'bob@example.com' already exists.)"
+              }
+        "401":
+          description: Permission denied
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "PERMISSION_DENIED",
+                "message": "The requested resource cannot be accessed using the provided permission rights. (unauthorized: accessor must be admin)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+
     delete:
       operationId: deleteUser
       parameters:


### PR DESCRIPTION
I want a way to create users in the new /v4/ paradigm. This will let me add validations and sanitization that are missing currently at the v1 endpoint.

It also lets us get closer to a point where we can remove all legacy from api, which is something I really want to do.

I know we intend to replace user management entirely in the short/medium term, but I don't want to have any more tech debt and confusion caused by things we know but are not fixing.