### PR TITLE
Spec a way to rename clusters

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -37,6 +37,9 @@ definitions:
     required: []
     description: Request body for cluster modification
     properties:
+      name:
+        type: string
+        description: Name for the cluster
       owner:
         type: string
         description: Name of the organization owning the cluster

--- a/spec.yaml
+++ b/spec.yaml
@@ -352,6 +352,8 @@ paths:
 
         The following attributes can be modified:
 
+        - `name`: Rename the cluster to something more fitting.
+
         - `owner`: Changing the owner organization name means to change cluster
         ownership from one organization to another. The user performing the
         request has to be a member of both organizations.


### PR DESCRIPTION
Pretty straightforward. Renaming clusters is just a matter of adding the `name` field to the already existing `PATCH` request for modifying clusters.

Issue: https://github.com/giantswarm/giantswarm/issues/870