### PR TITLE
Add cn_prefix and o to keypair requests (RBAC)

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -130,7 +130,7 @@ definitions:
         cn_prefix:
           type: string
           description: The common name prefix of the certificate subject.
-        o:
+        certificate_organizations:
           type: string
           description: The certificate subject's `organization` fields.
 

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -127,6 +127,12 @@ definitions:
         create_date:
           type: string
           description: Date/time of creation
+        cn_prefix:
+          type: string
+          description: The common name prefix of the certificate subject.
+        o:
+          type: string
+          description: The certificate subject's `organization` fields.
 
   # Add key pair request
   V4AddKeyPairRequest:
@@ -141,6 +147,12 @@ definitions:
         type: integer
         format: int32
         description: Expiration time (from creation) in hours
+      cn_prefix:
+        type: string
+        description: The common name prefix of the certificate subject.
+      o:
+        type: string
+        description: This will set the certificate subject's `organization` fields. Use a comma seperated list of values.
 
   V4AddKeyPairResponse:
     type: object

--- a/docserver/index.html
+++ b/docserver/index.html
@@ -16,6 +16,6 @@
   </head>
   <body>
     <redoc spec-url='yaml/spec.yaml'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/v1.17.0/redoc.min.js"></script>
+    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"></script>
   </body>
 </html>

--- a/docserver/index.html
+++ b/docserver/index.html
@@ -16,6 +16,6 @@
   </head>
   <body>
     <redoc spec-url='yaml/spec.yaml'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"></script>
+    <script src="https://rebilly.github.io/ReDoc/releases/v1.17.0/redoc.min.js"></script>
   </body>
 </html>

--- a/spec.yaml
+++ b/spec.yaml
@@ -523,7 +523,7 @@ paths:
           to set up role-based access controls.
 
 
-        - `o`: This will set the certificate's `organization` fields. Use a comma seperated list of values.
+        - `certificate_organizations`: This will set the certificate's `organization` fields. Use a comma seperated list of values.
           The Kubernetes API will use these values as group memberships.
 
         __Note:__ The actual credentials coming with the key pair (key, certificate) can only be accessed once, as the result of the `POST` request that triggers their creation. This restriction exists to minimize the risk of credentials being leaked. If you fail to capture the credentials upon creation, you'll have to repeat the creation request.

--- a/spec.yaml
+++ b/spec.yaml
@@ -507,6 +507,25 @@ paths:
 
         In addition to the credentials itself, a key pair has some metadata like a unique ID, a creation timestamp and a free text `description` that you can use at will, for example to note for whom a key pair has been issued.
 
+        ### Customizing the certificate's subject for K8s RBAC
+
+        It is possible to set the Common Name and Organization fields of the generated certificate's subject.
+
+        - `cn_prefix`: The certificate's common name uses this format: `<cn_prefix>.user.<clusterdomain>`.
+
+          `clusterdomain` is specific to your cluster and is not editable.
+
+          The `cn_prefix` however
+          is editable. When left blank it will default to the email address of the Giant Swarm user
+          that is performing the create key pair request.
+
+          The common name is used as the username for requests to the Kubernetes API. This allows you
+          to set up role-based access controls.
+
+
+        - `o`: This will set the certificate's `organization` fields. Use a comma seperated list of values.
+          The Kubernetes API will use these values as group memberships.
+
         __Note:__ The actual credentials coming with the key pair (key, certificate) can only be accessed once, as the result of the `POST` request that triggers their creation. This restriction exists to minimize the risk of credentials being leaked. If you fail to capture the credentials upon creation, you'll have to repeat the creation request.
       responses:
         "200":


### PR DESCRIPTION
@puja, @marians, and I discussed this last Thursday, that it was becoming important in the short term to be able to set the Common Name of certificates we generate during key pair creation. Since it allows for setting more granular RBAC permissions per certificate instead of granting full admin rights each time.

This PR proposes a way to achieve that for the end user.

Implementation considerations:

We want to allow only a prefix of the Common Name of the certificate to be defined by the user. This lets us avoid collisions with other k8s components, as well as ensures users won't be able to make certificates that have no chance of working, since the K8s API will reject certificates that aren't a subdomain of the clusterdomain.

To avoid collisions with other k8s components, user certificate's common names should be a subdomain of `user.clusterdomain` like: `oliverponder_giantswarm_io.user.clusterdomain`

While we're at it, it would also be nice to be able to set the O of the certificate subject. 

Relevant info:
https://kubernetes.io/docs/admin/authentication/#x509-client-certs