### PR TITLE
Fix wrong attribute name in the spec

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -130,9 +130,9 @@ definitions:
         create_date:
           type: string
           description: Date/time of creation
-        cn_prefix:
+        common_name:
           type: string
-          description: The common name prefix of the certificate subject.
+          description: The common name of the certificate subject.
         certificate_organizations:
           type: string
           description: The certificate subject's `organization` fields.


### PR DESCRIPTION
Cluster service stores the final common name, not just the prefix that the user supplied.
This PR corrects that in the spec.