### PR TITLE
Releases endpoint API spec

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -251,6 +251,7 @@ definitions:
   # A cluster array item, as return by getClusters
   V4ReleaseListItem:
     type: object
+    required: ["version", "timestamp", "changelog", "components"]
     properties:
       version:
         type: string
@@ -258,16 +259,28 @@ definitions:
       timestamp:
         type: string
         description: Date and time of the release creation
-      description:
-        type: string
-        description: |
-          Human-friendly description of the changes compared to the
-          prior version
-      deprecated:
+      active:
         type: boolean
         description: |
-          If true, the version is no longer available for new clusters and
-          cluster upgrades.
+          If true, the version is available for new clusters and cluster
+          upgrades. Older versions become unavailable and thus have the
+          value `false` here.
+      changelog:
+        description: |
+          Structured list of changes in this release, in comparison to the
+          previous version, with respect to the contained components.
+        type: array
+        items:
+          type: object
+          properties:
+            component:
+              type: string
+              description: |
+                If the changed item was a component, this attribute is the
+                name of the component.
+            description:
+              type: string
+              description: Human-friendly description of the change
       components:
         description: |
           List of components and their version contained in the release
@@ -282,8 +295,3 @@ definitions:
             version:
               type: string
               description: Version number of the component
-            description:
-              type: string
-              description: |
-                Human-readable information on the change of this component,
-                if applicable

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -9,7 +9,8 @@ definitions:
         description: A human readable message
       code:
         type: string
-        description: A machine readable [response code](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) like e. g. `INVALID_CREDENTIALS`
+        description: |
+          A machine readable [response code](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) like e. g. `INVALID_CREDENTIALS`
 
   # Request to create a new cluster
   V4AddClusterRequest:
@@ -84,11 +85,14 @@ definitions:
     properties:
       aws:
         type: object
-        description: Attributes specific to nodes running on Amazon Web Services (AWS)
+        description: |
+          Attributes specific to nodes running on Amazon Web Services (AWS)
         properties:
           instance_type:
             type: string
-            description: EC2 instance type name. Must be the same for all worker nodes of a cluster.
+            description: |
+              EC2 instance type name. Must be the same for all worker nodes
+              of a cluster.
       memory:
         type: object
         properties:
@@ -155,7 +159,9 @@ definitions:
         description: The common name prefix of the certificate subject.
       certificate_organizations:
         type: string
-        description: This will set the certificate subject's `organization` fields. Use a comma seperated list of values.
+        description: |
+          This will set the certificate subject's `organization` fields.
+          Use a comma seperated list of values.
 
   V4AddKeyPairResponse:
     type: object

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -247,3 +247,37 @@ definitions:
       owner:
         type: string
         description: Name of the organization owning the cluster
+
+  # A cluster array item, as return by getClusters
+  V4ReleaseListItem:
+    type: object
+    properties:
+      version:
+        type: string
+        description: The semantic version number
+      timestamp:
+        type: string
+        description: Date and time of the release creation
+      description:
+        type: string
+        description: |
+          Human-friendly description of the changes compared to the
+          prior version
+      deprecated:
+        type: boolean
+        description: |
+          If true, the version is no longer available for new clusters and
+          cluster upgrades.
+      components:
+        description: |
+          List of components and their version contained in the release
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+              description: Name of the component
+            version:
+              type: string
+              description: Version number of the component

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -274,6 +274,7 @@ definitions:
         type: array
         items:
           type: object
+          required: ["name", "version"]
           properties:
             name:
               type: string
@@ -281,3 +282,8 @@ definitions:
             version:
               type: string
               description: Version number of the component
+            description:
+              type: string
+              description: |
+                Human-readable information on the change of this component,
+                if applicable

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -21,4 +21,5 @@ parameters:
     type: string
     description: |
         An ID for the organization.
-        This ID must be unique and match this regular expression: ^[a-z0-9_]{4,30}$
+        This ID must be unique and match this regular
+        expression: ^[a-z0-9_]{4,30}$

--- a/spec.yaml
+++ b/spec.yaml
@@ -792,27 +792,31 @@ paths:
                   "components": [
                     {
                       "name": "kubernetes",
-                      "version": "1.5.8"
+                      "version": "1.5.8",
+                      "description": "Security fixes"
                     },
                     {
                       "name": "calico",
-                      "version": "0.9.1"
+                      "version": "0.9.1",
+                      "description": "Security fixes"
                     }
                   ],
                   "deprecated": true
                 },
                 {
-                  "version": "2.8.3",
+                  "version": "2.8.4",
                   "timestamp": "2017-11-11T12:24:56.59969Z",
                   "description": "Minor update of calico, fixing a bug.",
                   "components": [
                     {
                       "name": "kubernetes",
-                      "version": "1.7.3"
+                      "version": "1.7.3",
+                      "description": null
                     },
                     {
                       "name": "calico",
-                      "version": "1.1.0"
+                      "version": "1.1.1",
+                      "description": "Bugfix"
                     }
                   ],
                   "deprecated": false

--- a/spec.yaml
+++ b/spec.yaml
@@ -100,7 +100,8 @@ paths:
         - users
       summary: Delete user
       description: |
-        Deletes a users in the system. Currently this endpoint is only available to users with admin permissions.
+        Deletes a users in the system. Currently this endpoint is only available
+        to users with admin permissions.
       responses:
         "200":
           description: User deleted

--- a/spec.yaml
+++ b/spec.yaml
@@ -46,7 +46,17 @@ tags:
   - name: users
     description: A user represents a person that should have access to the Giant Swarm API. Users can belong to many groups, and are identified by email address.
   - name: releases
-    description: A release is a software bundle that constitutes a cluster
+    description: |
+      A release is a software bundle that constitutes a cluster.
+
+      Releases are identified by their
+      [semantic version number](http://semver.org/) in the `MAJOR.MINOR.PATCH`
+      format.
+
+      A release provides _components_, like for example kubernetes. For each
+      release the contained components are listed. Changes in components are
+      detailed in the _changelog_ of a release.
+
 securityDefinitions:
   token_auth:
     description: Currently the only supported authentication scheme is passing an auth token via the `Authorization` header with a value of the format `giantswarm <token>`.
@@ -788,7 +798,6 @@ paths:
                 {
                   "version": "1.14.9",
                   "timestamp": "2017-09-21T08:14:03.37759Z",
-                  "description": "Minor updates of kubernetes and calico, both for security fixes.",
                   "changelog": [
                     {
                       "component": "kubernetes",
@@ -809,12 +818,11 @@ paths:
                       "version": "0.9.1"
                     }
                   ],
-                  "deprecated": true
+                  "active": false
                 },
                 {
                   "version": "2.8.4",
                   "timestamp": "2017-11-11T12:24:56.59969Z",
-                  "description": "Minor update of calico, fixing a bug.",
                   "changelog": [
                     {
                       "component": "calico",
@@ -831,6 +839,6 @@ paths:
                       "version": "1.1.1"
                     }
                   ],
-                  "deprecated": false
+                  "active": true
                 }
               ]

--- a/spec.yaml
+++ b/spec.yaml
@@ -789,16 +789,24 @@ paths:
                   "version": "1.14.9",
                   "timestamp": "2017-09-21T08:14:03.37759Z",
                   "description": "Minor updates of kubernetes and calico, both for security fixes.",
-                  "components": [
+                  "changelog": [
                     {
-                      "name": "kubernetes",
-                      "version": "1.5.8",
+                      "component": "kubernetes",
                       "description": "Security fixes"
                     },
                     {
-                      "name": "calico",
-                      "version": "0.9.1",
+                      "component": "calico",
                       "description": "Security fixes"
+                    }
+                  ],
+                  "components": [
+                    {
+                      "name": "kubernetes",
+                      "version": "1.5.8"
+                    },
+                    {
+                      "name": "calico",
+                      "version": "0.9.1"
                     }
                   ],
                   "deprecated": true
@@ -807,16 +815,20 @@ paths:
                   "version": "2.8.4",
                   "timestamp": "2017-11-11T12:24:56.59969Z",
                   "description": "Minor update of calico, fixing a bug.",
+                  "changelog": [
+                    {
+                      "component": "calico",
+                      "description": "Bugfix"
+                    }
+                  ],
                   "components": [
                     {
                       "name": "kubernetes",
-                      "version": "1.7.3",
-                      "description": null
+                      "version": "1.7.3"
                     },
                     {
                       "name": "calico",
-                      "version": "1.1.1",
-                      "description": "Bugfix"
+                      "version": "1.1.1"
                     }
                   ],
                   "deprecated": false

--- a/spec.yaml
+++ b/spec.yaml
@@ -45,6 +45,8 @@ tags:
     description: Organizations are groups of users who own resources like clusters.
   - name: users
     description: A user represents a person that should have access to the Giant Swarm API. Users can belong to many groups, and are identified by email address.
+  - name: releases
+    description: A release is a software bundle that constitutes a cluster
 securityDefinitions:
   token_auth:
     description: Currently the only supported authentication scheme is passing an auth token via the `Authorization` header with a value of the format `giantswarm <token>`.
@@ -760,3 +762,59 @@ paths:
           description: Error
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/releases/:
+    get:
+      operationId: getReleases
+      tags:
+        - releases
+      summary: Get releases
+      description: |
+        Lists all releases available for new clusters or for upgrading existing
+        clusters. Might also serve as an archive to obtain details on older
+        releases.
+      parameters:
+        - $ref: 'parameters.yaml#/parameters/OrganizationIdPathParameter'
+      responses:
+        "200":
+          description: Releases list
+          schema:
+            type: array
+            items:
+              $ref: "definitions.yaml#/definitions/V4ReleaseListItem"
+          examples:
+            application/json:
+              [
+                {
+                  "version": "1.14.9",
+                  "timestamp": "2017-09-21T08:14:03.37759Z",
+                  "description": "Minor updates of kubernetes and calico, both for security fixes.",
+                  "components": [
+                    {
+                      "name": "kubernetes",
+                      "version": "1.5.8"
+                    },
+                    {
+                      "name": "calico",
+                      "version": "0.9.1"
+                    }
+                  ],
+                  "deprecated": true
+                },
+                {
+                  "version": "2.8.3",
+                  "timestamp": "2017-11-11T12:24:56.59969Z",
+                  "description": "Minor update of calico, fixing a bug.",
+                  "components": [
+                    {
+                      "name": "kubernetes",
+                      "version": "1.7.3"
+                    },
+                    {
+                      "name": "calico",
+                      "version": "1.1.0"
+                    }
+                  ],
+                  "deprecated": false
+                }
+              ]


### PR DESCRIPTION
Part of https://github.com/giantswarm/giantswarm/issues/2022

This spec change introduces an endpoint that allows the API to inform users/clients which versions of guest cluster software/config are available both for creation of new guest clusters and for upgrades of existing guest clusters.

Status: Will be merged when implemented