### PR TITLE
Fixing success status code for createUser

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -200,7 +200,7 @@ paths:
       description: |
         Creates a users in the system. Currently this endpoint is only available to users with admin permissions.
       responses:
-        "200":
+        "201":
           description: User created
           schema:
             $ref: "definitions.yaml#/definitions/V4GenericResponse"


### PR DESCRIPTION
The API in fact returns 201, which is the right thing to do, in case of success after the PUT request.