### PR TITLE
Renaming securityDefinition, adding security section

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -60,12 +60,14 @@ tags:
       detailed in the _changelog_ of a release.
 
 securityDefinitions:
-  token_auth:
+  AuthorizationHeaderToken:
     description: Currently the only supported authentication scheme is passing an auth token via the `Authorization` header with a value of the format `giantswarm <token>`.
     type: apiKey
     name: Authorization
     in: header
 
+security:
+  - AuthorizationHeaderToken: []
 
 paths:
   /v4/info/:


### PR DESCRIPTION
This PR adds a missing `security` top level section to the spec which references the securityDefinition we have. This is required so that generated clients provide an authentication mechanism.

This is required by https://github.com/giantswarm/giantswarm-js-client/pull/46

As a cleanup, it also renames the securityDefinition from `AuthorizationHeaderToken` to `token_auth`.