### PR TITLE
Remove host and schemes fields

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -1,7 +1,4 @@
 swagger: "2.0"
-host: api.giantswarm.io
-schemes:
-  - https
 info:
   title: The Giant Swarm API v4
   description: |


### PR DESCRIPTION
The host and schemes field, in combination, results in a base URI of `https://api.giantswarm.io/` being communicated in the spec/docs and being hard coded into generated clients. This makes no sense, as we have a specific base URI per installation.