### PR TITLE
Dereference nested items so that swagger-codegen works.

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -158,19 +158,16 @@ definitions:
               Reveals the ports on the host cluster that are mapped to this guest cluster's ingress
               and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.
             items:
-              $ref: '#/definitions/V4PortMappingDefinition'
-
-  V4PortMappingDefinition:
-    type: object
-    properties:
-      port:
-        description: |
-          The port on the host cluster that will forward traffic to the guest cluster
-        type: integer
-      protocol:
-        description: |
-          The protocol this port mapping is made for.
-        type: string
+              type: object
+              properties:
+                port:
+                  description: |
+                    The port on the host cluster that will forward traffic to the guest cluster
+                  type: integer
+                protocol:
+                  description: |
+                    The protocol this port mapping is made for.
+                  type: string
 
   # Definition of a cluster node
   V4NodeDefinition:
@@ -313,45 +310,140 @@ definitions:
         type: object
         properties:
           container_count:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           pod_count:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           cpu_used:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           ram_free:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           ram_available:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           ram_cached:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           ram_buffers:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           ram_mapped:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           node_storage_used:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           network_rx:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           network_tx:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           resource_cpu_requests:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           resource_cpu_limits:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           resource_ram_requests:
-            $ref: '#/definitions/V4Metric'
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
           resource_ram_limits:
-            $ref: '#/definitions/V4Metric'
-
-  V4Metric:
-    type: object
-    properties:
-      timestamp:
-        description: Time when the given value has been recorded
-        type: string
-      value:
-        description: The value for the metric. Can be an integer or float.
-        type: number
+            type: object
+            properties:
+              timestamp:
+                description: Time when the given value has been recorded
+                type: string
+              value:
+                description: The value for the metric. Can be an integer or float.
+                type: number
 
   # a complete organization object
   V4Organization:


### PR DESCRIPTION
swagger-codegen was not generating the models for V4Metrics or the PortMappings. 
"Dereferencing" them as is done in this PR allowed the client to be generated properly.

Related: https://github.com/giantswarm/giantswarm-js-client/pull/48