### PR TITLE
Add addCredentials operation

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -581,7 +581,7 @@ definitions:
         type: string
       aws:
         type: object
-        description: Credentials specific to an AWS
+        description: Credentials specific to an AWS account
         required:
           - account_id
           - access_key_id

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -568,3 +568,31 @@ definitions:
       expiry:
         type: string
         description: The date and time when this account will expire
+
+  V4AddCredentialsRequest:
+    type: object
+    required:
+      - provider
+    description: Request model for adding a set of credentials
+    properties:
+      provider:
+        type: string
+      description:
+        type: string
+      aws:
+        type: object
+        description: Credentials specific to an AWS
+        required:
+          - account_id
+          - access_key_id
+          - secret_access_key
+        properties:
+          account_id:
+            type: string
+            description: AWS account ID (usually a numeric string)
+          access_key_id:
+            type: string
+            description: AWS access key ID, base46-encoded
+          secret_access_key:
+            type: string
+            description: AWS secret access key ID, base46-encoded

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -577,22 +577,21 @@ definitions:
     properties:
       provider:
         type: string
-      description:
-        type: string
       aws:
-        type: object
+        type: array
         description: Credentials specific to an AWS account
-        required:
-          - account_id
-          - access_key_id
-          - secret_access_key
-        properties:
-          account_id:
-            type: string
-            description: AWS account ID (usually a numeric string)
-          access_key_id:
-            type: string
-            description: AWS access key ID, base46-encoded
-          secret_access_key:
-            type: string
-            description: AWS secret access key ID, base46-encoded
+        items:
+          type: object
+          required:
+            - purpose
+            - role_arn
+          properties:
+            purpose:
+              type: string
+              description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `staff` (for Giant Swarm team members).
+            role_arn:
+              type: string
+              description: The Amazon Resource Name (ARN) of the role created for the purpose
+            external_id:
+              type: string
+              description: The "external ID" required for assuming the role. Only when `purpose` is `aws-operator`.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -584,16 +584,15 @@ definitions:
           - roles
         properties:
           roles:
-            type: array
-            items:
-              type: object
-              required:
-                - purpose
-                - arn
-              properties:
-                purpose:
-                  type: string
-                  description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `admin` (for Giant Swarm staff).
-                role_arn:
-                  type: string
-                  description: The Amazon Resource Name (ARN) of the role created for the purpose
+            type: object
+            descriptions: IAM roles to assume by certain entities
+            required:
+              - awsoperator
+              - admin
+            properties:
+              admin:
+                type: string
+                description: ARN of the IAM role to assume by Giant Swarm support staff
+              awsoperator:
+                type: string
+                description: ARN of the IAM role to assume by the software operating clusters

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -578,17 +578,22 @@ definitions:
       provider:
         type: string
       aws:
-        type: array
+        type: object
         description: Credentials specific to an AWS account
-        items:
-          type: object
-          required:
-            - purpose
-            - role_arn
-          properties:
-            purpose:
-              type: string
-              description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `admin` (for Giant Swarm staff).
-            role_arn:
-              type: string
-              description: The Amazon Resource Name (ARN) of the role created for the purpose
+        required:
+          - roles
+        properties:
+          roles:
+            type: array
+            items:
+              type: object
+              required:
+                - purpose
+                - arn
+              properties:
+                purpose:
+                  type: string
+                  description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `admin` (for Giant Swarm staff).
+                role_arn:
+                  type: string
+                  description: The Amazon Resource Name (ARN) of the role created for the purpose

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -588,10 +588,7 @@ definitions:
           properties:
             purpose:
               type: string
-              description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `staff` (for Giant Swarm team members).
+              description: Purpose of the role. Either `aws-operator` (for the software operating clusters) or `admin` (for Giant Swarm staff).
             role_arn:
               type: string
               description: The Amazon Resource Name (ARN) of the role created for the purpose
-            external_id:
-              type: string
-              description: The "external ID" required for assuming the role. Only when `purpose` is `aws-operator`.

--- a/spec.yaml
+++ b/spec.yaml
@@ -1025,12 +1025,11 @@ paths:
           "aws": [
             {
               "purpose": "aws-operator",
-              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator",
-              "external_id": "base-64-encoded-string"
+              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
             },
             {
-              "purpose": "staff",
-              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmStaff"
+              "purpose": "admin",
+              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAdmin"
             }
           ]
         }

--- a/spec.yaml
+++ b/spec.yaml
@@ -997,6 +997,58 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v4/organizations/{organization_id}/credentials/:
+    post:
+      operationId: addCredentials
+      tags:
+        - organizations
+      summary: Set credentials
+      description: |
+        Add a set of credentials to the organization allowing to create and
+        operate clusters within a cloud provider account/subscription.
+
+        Credentials in an organization are immutable. An organization can only
+        have one set of credentials.
+
+        Once credentials have been set for an organization, they are used for
+        every new cluster that will be created for the organization.
+      parameters:
+        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+        - name: body
+          in: body
+          required: true
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AddCredentialsRequest"
+      responses:
+        "201":
+          description: Credentials created
+          headers:
+            Location:
+              type: string
+              description: URI of the new credentials resource
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "A new set of credentials has been created with ID '5d9h4'"
+              }
+        "409":
+          description: Conflict
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "The organisation already has a set of credentials"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
   /v4/releases/:
     get:
       operationId: getReleases

--- a/spec.yaml
+++ b/spec.yaml
@@ -1022,16 +1022,18 @@ paths:
         ```json
         {
           "provider": "aws",
-          "aws": [
-            {
-              "purpose": "aws-operator",
-              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
-            },
-            {
-              "purpose": "admin",
-              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAdmin"
-            }
-          ]
+          "aws": {
+            "roles": [
+              {
+                "purpose": "aws-operator",
+                "arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+              },
+              {
+                "purpose": "admin",
+                "arn": "arn:aws:iam::123456789012:role/GiantSwarmAdmin"
+              }
+            ]
+          }
         }
         ```
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -1023,16 +1023,10 @@ paths:
         {
           "provider": "aws",
           "aws": {
-            "roles": [
-              {
-                "purpose": "aws-operator",
-                "arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
-              },
-              {
-                "purpose": "admin",
-                "arn": "arn:aws:iam::123456789012:role/GiantSwarmAdmin"
-              }
-            ]
+            "roles": {
+              "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
+              "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+            }
           }
         }
         ```

--- a/spec.yaml
+++ b/spec.yaml
@@ -1004,8 +1004,8 @@ paths:
         - organizations
       summary: Set credentials
       description: |
-        Add a set of credentials to the organization allowing to create and
-        operate clusters within a cloud provider account/subscription.
+        Add a set of credentials to the organization allowing the creation and
+        operation of clusters within a cloud provider account/subscription.
 
         Credentials in an organization are immutable. An organization can only
         have one set of credentials.

--- a/spec.yaml
+++ b/spec.yaml
@@ -1007,11 +1007,36 @@ paths:
         Add a set of credentials to the organization allowing the creation and
         operation of clusters within a cloud provider account/subscription.
 
-        Credentials in an organization are immutable. An organization can only
+        The actual type of these credentials depends on the cloud provider the
+        installation is running on. Currently, only AWS is supported, with
+        support for Azure being planned for the near future.
+
+        Credentials in an organization are immutable. Each organization can only
         have one set of credentials.
 
         Once credentials have been set for an organization, they are used for
         every new cluster that will be created for the organization.
+
+        ### Example request body for AWS
+
+        ```json
+        {
+          "provider": "aws",
+          "aws": [
+            {
+              "purpose": "aws-operator",
+              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator",
+              "external_id": "base-64-encoded-string"
+            },
+            {
+              "purpose": "staff",
+              "role_arn": "arn:aws:iam::123456789012:role/GiantSwarmStaff"
+            }
+          ]
+        }
+        ```
+
+
       parameters:
         - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
         - name: body


### PR DESCRIPTION
Towards
- https://github.com/giantswarm/giantswarm/issues/2944
- https://github.com/giantswarm/giantswarm/issues/2652 (epic)

This PR adds the spec for a `addCredentials` operation that allows to set the provider credentials for an organization.

### Preview

For an AWS installation and an organization named `acme`, this is how credentials could be specified:

```nohighlight
curl -X POST -H "Authorization: giantswarm $TOKEN" $API_ENDPOINT/v4/organizations/acme/credentials/ -d '
{
  "provider": "aws",
  "aws": {
    "roles": {
      "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
      "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
    }
  }
}'
```

Response:

```nohighlight
HTTP/1.1 201 Created
Location: /v4/organizations/acme/credentials/abc123/
Content-type: application/json

{
  "code": "RESOURCE_CREATED",
  "message": "A new set of credentials has been created with ID 'abc123'"
}
```
