### PR TITLE
Include ReDoc JS file in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,11 @@ FROM nginx:1.14-alpine
 RUN rm -r /etc/nginx/conf.d
 ADD docserver/index.html /www/
 ADD *.yaml /www/yaml/
+
+RUN mkdir /www/js
+ADD https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js /www/js/redoc.min.js
+RUN chmod 0644 /www/js/redoc.min.js
+
 ADD docserver/nginx.conf /etc/nginx/
+
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.13-alpine
+FROM nginx:1.14-alpine
 RUN rm -r /etc/nginx/conf.d
 ADD docserver/index.html /www/
 ADD *.yaml /www/yaml/

--- a/docserver/index.html
+++ b/docserver/index.html
@@ -16,6 +16,6 @@
   </head>
   <body>
     <redoc spec-url='yaml/spec.yaml'></redoc>
-    <script src="https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js"></script>
+    <script src="js/redoc.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This avoids relying on ReDoc being available at runtime and also reduced the amount of third party tracking. See https://github.com/giantswarm/giantswarm/issues/3232