### PR TITLE
Fix type of storage.size_gb and clarify description

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -198,13 +198,13 @@ definitions:
         properties:
           size_gb:
             type: number
-            description: RAM size in GB
+            description: RAM size in GB. Can be an integer or float.
       storage:
         type: object
         properties:
           size_gb:
-            type: integer
-            description: Node storage size in GB
+            type: number
+            description: Node storage size in GB. Can be an integer or float.
       cpu:
         type: object
         properties:


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3449

This fixes a problem with a wrong type definition (int vs. number) and also makes it more explicit in the description that here, both an integer and a floating point value can occur.