### PR TITLE
Document cn_prefix charset in API spec

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -256,7 +256,7 @@ definitions:
         description: Expiration time (from creation) in hours
       cn_prefix:
         type: string
-        description: The common name prefix of the certificate subject.
+        description: The common name prefix of the certificate subject. This only allows characters that are usable in domain names (`a-z`, `0-9`, and `.-`, where `.-` must not occur at the start nor end).
       certificate_organizations:
         type: string
         description: |

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -256,7 +256,7 @@ definitions:
         description: Expiration time (from creation) in hours
       cn_prefix:
         type: string
-        description: The common name prefix of the certificate subject. This only allows characters that are usable in domain names (`a-z`, `0-9`, and `.-`, where `.-` must not occur at the start nor end).
+        description: The common name prefix of the certificate subject. This only allows characters that are usable in domain names (`a-z`, `0-9`, and `.-`, where `.-` must not occur at either the start or the end).
       certificate_organizations:
         type: string
         description: |

--- a/spec.yaml
+++ b/spec.yaml
@@ -855,9 +855,9 @@ paths:
 
           `clusterdomain` is specific to your cluster and is not editable.
 
-          The `cn_prefix` however
-          is editable. When left blank it will default to the email address of the Giant Swarm user
-          that is performing the create key pair request.
+          The `cn_prefix` however is editable. When left blank it will default
+          to the email address of the Giant Swarm user that is performing the
+          create key pair request.
 
           The common name is used as the username for requests to the Kubernetes API. This allows you
           to set up role-based access controls.


### PR DESCRIPTION
For https://github.com/giantswarm/api/issues/475

It seems like vault's PKI implementation requires the entire CN to be a valid domain name (in terms of the character set used). I tested this myself, as I couldn't get a source for the actual validation in place.