### PR TITLE
Add 401 responses everywhere

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PWD := $(shell pwd)
 PHONY: lint spec-tmp.yaml
 
 SWAGGER_VERSION=2.2.3
@@ -15,7 +16,12 @@ spec-tmp.yaml:
 
 # YAML linting
 lint: spec-tmp.yaml
-	yamllint -c ./yamllint/config.yaml ./spec.yaml ./definitions.yaml ./parameters.yaml ./responses.yaml
+	docker run --rm -ti \
+		-v $(PWD):/workdir \
+		-w /workdir \
+		giantswarm/yamllint \
+		-c ./yamllint/config.yaml \
+		./spec.yaml ./definitions.yaml ./parameters.yaml ./responses.yaml
 
 # Validate the swagger/OAI spec
 validate: spec-tmp.yaml lint

--- a/responses.yaml
+++ b/responses.yaml
@@ -1,0 +1,12 @@
+responses:
+
+  V4Generic401Response:
+    description: Permission denied
+    schema:
+      $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    examples:
+      application/json:
+        {
+          "code": "PERMISSION_DENIED",
+          "message": "The requested resource cannot be accessed using the provided authentication details."
+        }

--- a/spec.yaml
+++ b/spec.yaml
@@ -153,6 +153,8 @@ paths:
                   }
                 }
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -289,6 +291,8 @@ paths:
           examples:
             application/json:
               {"email": "andy@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: User not found
           schema:
@@ -434,6 +438,8 @@ paths:
                   "owner": "testorg"
                 }
               ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -576,6 +582,8 @@ paths:
                   ]
                 }
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Cluster not found
           schema:
@@ -680,6 +688,8 @@ paths:
           description: Cluster modified
           schema:
             $ref: "./definitions.yaml#/definitions/V4ClusterDetailsResponse"
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Cluster not found
           schema:
@@ -719,6 +729,8 @@ paths:
                 "code": "RESOURCE_DELETION_STARTED",
                 "message": "The cluster with ID 'wqtlq' is being deleted."
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Cluster not found
           schema:
@@ -751,6 +763,8 @@ paths:
           description: Key pairs
           schema:
             $ref: "./definitions.yaml#/definitions/V4GetKeyPairsResponse"
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: error
           schema:
@@ -819,6 +833,8 @@ paths:
                 "id": "02:cc:da:f9:fb:ce:c3:e5:e1:f6:27:d8:43:48:0d:37:4a:ee:b9:67",
                 "ttl_hours": 8640
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
 
   /v4/organizations/:
     get:
@@ -844,6 +860,8 @@ paths:
                 {"id": "giantswarm"},
                 {"id": "testorg"}
               ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:

--- a/spec.yaml
+++ b/spec.yaml
@@ -324,8 +324,6 @@ paths:
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The user could not be found. (not found: user with email 'bob@example.com' could not be found)"
               }
-        "401":
-          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:

--- a/spec.yaml
+++ b/spec.yaml
@@ -183,22 +183,15 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "definitions.yaml#/definitions/V4CreateAuthTokenResponse"
+            $ref: "./definitions.yaml#/definitions/V4CreateAuthTokenResponse"
           examples:
             application/json:
               {
                 "auth_token": "e5239484-2299-41df-b901-d0568db7e3f9"
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided authentication details. Email or password is not correct."
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+
     delete:
       operationId: deleteAuthToken
       tags:
@@ -216,24 +209,15 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "definitions.yaml#/definitions/V4GenericResponse"
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
           examples:
             application/json:
               {
                 "code": "RESOURCE_DELETED",
                 "message": "The authentication token has been succesfully deleted."
               }
-
         "401":
-          description: Permission denied
-          schema:
-            $ref: "definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided authentication details. Email or password is not correct."
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
 
   /v4/users/:
     get:
@@ -258,15 +242,7 @@ paths:
                 {"email": "charles@example.com", "created": "2017-03-15T13:00:00Z", "expiry": "2021-01-15T00:00:00Z"}
               ]
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights. (unauthorized: accessor must be admin)"
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -289,15 +265,7 @@ paths:
             application/json:
               {"email": "andy@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights."
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -332,15 +300,7 @@ paths:
                 "message": "The user could not be found. (not found: user with email 'bob@example.com' could not be found)"
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights."
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -389,15 +349,7 @@ paths:
                 "message": "The user could not be created. (invalid input: email 'bob@example.com' already exists)"
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights. (unauthorized: accessor must be admin)"
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: Error
           schema:
@@ -424,6 +376,8 @@ paths:
                 "code": "RESOURCE_DELETED",
                 "message": "The user with email 'bob@example.com' has been deleted."
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: User not found
           schema:
@@ -433,16 +387,6 @@ paths:
               {
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The user could not be deleted. (not found: user with email 'bob@example.com' could not be found)"
-              }
-        "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights. (unauthorized: accessor must be admin)"
               }
         default:
           description: Error
@@ -562,15 +506,7 @@ paths:
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The requested resource cannot be accessed using the provided permission rights. Please make sure you are a member of the organization you set in the 'owner' field."
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: error
           schema:
@@ -937,18 +873,8 @@ paths:
                   {"email": "user2@example.com"}
                 ]
               }
-
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The details of the organization could not be listed. (unauthorized: you must be a member of 'acme')"
-              }
-
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Organization not found
           schema:
@@ -1000,7 +926,8 @@ paths:
                   {"email": "user2@example.com"}
                 ]
               }
-
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "409":
           description: Organization already exists
           schema:
@@ -1071,15 +998,7 @@ paths:
                 "message": "The organization could not be modified. (invalid input: user 'invalid-email' does not exist or is invalid)"
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The organization could not be modified. (unauthorized: you must be a member of 'acme')"
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Organization not found
           schema:
@@ -1116,15 +1035,7 @@ paths:
                 "message": "The organization with ID 'acme' has been deleted."
               }
         "401":
-          description: Permission denied
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "PERMISSION_DENIED",
-                "message": "The organization could not be deleted. (unauthorized: you must be a member of 'acme')"
-              }
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":
           description: Organization not found
           schema:
@@ -1207,6 +1118,8 @@ paths:
                 "code": "RESOURCE_CREATED",
                 "message": "A new set of credentials has been created with ID '5d9h4'"
               }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
         "409":
           description: Conflict
           schema:
@@ -1289,3 +1202,5 @@ paths:
                   "active": true
                 }
               ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"


### PR DESCRIPTION
Related to https://github.com/giantswarm/gsctl/pull/251

This PR ensures that there is a 401 response defined for every operation. It uses referenes to one generic example for that.

Rationale is that this allows the new client to operate in a consistent way accross all operations. The code generated by go-swagger is different, depending on whether a response is defined or not. To have it consistent we could either have no specific responses anywhere and use the "default" for anything other than 200 (which is bad from a documentation point of view) or have every specific response specified.

Expect more of these PRs the near future.