### PR TITLE
Remove Authorization header from createAuthToken

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -174,7 +174,6 @@ paths:
       description: |
         Creates a Auth Token for a given user. Must authenticate with email and password.
       parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'


### PR DESCRIPTION
I made a mistake here in https://github.com/giantswarm/api-spec/pull/98 as the createAuthToken operation of course cannot accept an `Authorization` header. 