### PR TITLE
Add patch user endpoint

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -569,14 +569,6 @@ definitions:
         type: string
         description: The date and time when this account will expire
 
-  V4ModifyCurrentUserRequest:
-    type: object
-    description: Request model for modifying your own profile
-    properties:
-      email:
-        type: string
-        description: Set the new email address you would like to have.
-
   V4ModifyUserRequest:
     type: object
     description: Request model for modifying a specific user as an admin
@@ -586,7 +578,7 @@ definitions:
         description: Set the new email address you would like the user to have.
       expiry:
         type: string
-        description: Set the new expiry date you would like the user to have.
+        description: Set the new expiry date you would like the user to have. (Only editable by admins)
 
   V4AddCredentialsRequest:
     type: object

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -569,6 +569,25 @@ definitions:
         type: string
         description: The date and time when this account will expire
 
+  V4ModifyCurrentUserRequest:
+    type: object
+    description: Request model for modifying your own profile
+    properties:
+      email:
+        type: string
+        description: Set the new email address you would like to have.
+
+  V4ModifyUserRequest:
+    type: object
+    description: Request model for modifying a specific user as an admin
+    properties:
+      email:
+        type: string
+        description: Set the new email address you would like the user to have.
+      expiry:
+        type: string
+        description: Set the new expiry date you would like the user to have.
+
   V4AddCredentialsRequest:
     type: object
     required:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -571,14 +571,14 @@ definitions:
 
   V4ModifyUserRequest:
     type: object
-    description: Request model for modifying a specific user as an admin
+    description: Request model for modifying a specific user
     properties:
       email:
         type: string
-        description: Set the new email address you would like the user to have.
+        description: New email address
       expiry:
         type: string
-        description: Set the new expiry date you would like the user to have. (Only editable by admins)
+        description: New expiry date. (Only editable by admins)
 
   V4AddCredentialsRequest:
     type: object

--- a/spec.yaml
+++ b/spec.yaml
@@ -289,6 +289,45 @@ paths:
           description: Error
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    patch:
+      operationId: modifyCurrentUser
+      tags:
+        - users
+      summary: Modify current user
+      description: |
+        This operation allows you to change details of your own account. Currently only the 'email' field can be edited.
+        If you are an admin looking to edit other accounts, take a look at the Modify User endpoint.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: User account details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ModifyCurrentUserRequest"
+          x-examples:
+            application/json:
+              {
+                "email": "edited-email@example.com"
+              }
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4UserListItem"
+          examples:
+            application/json:
+              {"email": "edited-email@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
 
   /v4/users/{email}/:
     get:
@@ -381,6 +420,45 @@ paths:
           description: Error
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    patch:
+      operationId: modifyUser
+      tags:
+        - users
+      summary: Modify user
+      description: |
+        This operation allows you to change details of a given user. This endpoint is only available to admins.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: User account details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ModifyUserRequest"
+          x-examples:
+            application/json:
+              {
+                "email": "edited-email@example.com",
+                "expiry": "2037-01-15T00:00:00Z"
+              }
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4UserListItem"
+          examples:
+            application/json:
+              {"email": "edited-email@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2037-01-15T00:00:00Z"}
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
 
     delete:
       operationId: deleteUser

--- a/spec.yaml
+++ b/spec.yaml
@@ -289,45 +289,6 @@ paths:
           description: Error
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-    patch:
-      operationId: modifyCurrentUser
-      tags:
-        - users
-      summary: Modify current user
-      description: |
-        This operation allows you to change details of your own account. Currently only the 'email' field can be edited.
-        If you are an admin looking to edit other accounts, take a look at the Modify User endpoint.
-      parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
-        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
-        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
-        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
-        - name: body
-          in: body
-          required: true
-          description: User account details
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4ModifyCurrentUserRequest"
-          x-examples:
-            application/json:
-              {
-                "email": "edited-email@example.com"
-              }
-      responses:
-        "200":
-          description: Success
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4UserListItem"
-          examples:
-            application/json:
-              {"email": "edited-email@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2019-01-15T00:00:00Z"}
-        "401":
-          $ref: "./responses.yaml#/responses/V4Generic401Response"
-        default:
-          description: Error
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-
 
   /v4/users/{email}/:
     get:
@@ -426,7 +387,7 @@ paths:
         - users
       summary: Modify user
       description: |
-        This operation allows you to change details of a given user. This endpoint is only available to admins.
+        This operation allows you to change details of a given user. Only administrators can edit accounts of other users.
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'

--- a/spec.yaml
+++ b/spec.yaml
@@ -412,7 +412,11 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4UserListItem"
           examples:
             application/json:
-              {"email": "edited-email@example.com", "created": "2017-01-15T12:00:00Z", "expiry": "2037-01-15T00:00:00Z"}
+              {
+                "email": "edited-email@example.com",
+                "created": "2017-01-15T12:00:00Z",
+                "expiry": "2037-01-15T00:00:00Z"
+              }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:

--- a/spec.yaml
+++ b/spec.yaml
@@ -393,6 +393,7 @@ paths:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/UserEmailPathParameter"
         - name: body
           in: body
           required: true


### PR DESCRIPTION
This PR adds a spec for PATCH to our user resource endpoint.

~PATCH `/v4/user/`:~
~Allows someone to modify their own e-mail address.~

PATCH `/v4/users/:email/`:
Allows to modify a given user's e-mail address and/or their expiry date. Only admins are able to edit accounts that don't belong to them, as well as the expiry date.