### PR TITLE
Add spec for inviting users.

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -683,12 +683,12 @@ definitions:
       created:
         type: string
         description: Date/Time that the invitation was created
-      expiry:
-        type: string
-        description: Date/Time that the invitation will expire
       email:
         type: string
         description: Email of the invitee
+      expiry:
+        type: string
+        description: Date/Time that the invitation will expire
       invited_by:
         type: string
         description: Email of the person that created the invitation
@@ -717,24 +717,3 @@ definitions:
       send_email:
         type: boolean
         description: Whether or not to send the invitee an email. Defaults to true
-
-  V4CreateInvitationResponse:
-    type: object
-    properties:
-      created:
-        type: string
-        description: Date/Time that the invitation was created
-      email:
-        type: string
-        description: Email of the invitee
-      invitation_accept_link:
-        type: string
-        description: A link that can be used to accept the invitation.
-      invited_by:
-        type: string
-        description: Email of the person that created the invitation
-      organizations:
-        type: array
-        description: List of organizations that the invitee will be added to
-        items:
-          type: string

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -683,6 +683,9 @@ definitions:
       created:
         type: string
         description: Date/Time that the invitation was created
+      expiry:
+        type: string
+        description: Date/Time that the invitation will expire
       email:
         type: string
         description: Email of the invitee

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -747,4 +747,3 @@ definitions:
       status:
         type: string
         description: The status of the invitation. Either 'pending', 'accepted', or 'expired'
-

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -680,9 +680,6 @@ definitions:
       accepted:
         type: string
         description: Date/Time that the invitation was accepted
-      account_expiry_days:
-        type: integer
-        description: The number of days after which the account should expire
       created:
         type: string
         description: Date/Time that the invitation was created
@@ -706,9 +703,6 @@ definitions:
     required:
       - email
     properties:
-      account_expiry_days:
-        type: integer
-        description: The number of days after which the account should expire. Defaults to '0', which means never expire
       email:
         type: string
         description: The email of the person you want to invite
@@ -724,9 +718,6 @@ definitions:
   V4CreateInvitationResponse:
     type: object
     properties:
-      account_expiry_days:
-        type: integer
-        description: The number of days after which the account should expire
       created:
         type: string
         description: Date/Time that the invitation was created

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -666,3 +666,85 @@ definitions:
       auth_token:
         type: string
         description: The newly created API token
+
+  # The list of all invitations.
+  V4InvitationsResponse:
+    type: array
+    description: List of members that belong to this organization
+    items:
+      $ref: '#/definitions/V4Invitation'
+
+  V4Invitation:
+    type: object
+    properties:
+      accepted:
+        type: string
+        description: Date/Time that the invitation was accepted
+      account_expiry_days:
+        type: integer
+        description: The number of days after which the account should expire
+      created:
+        type: string
+        description: Date/Time that the invitation was created
+      email:
+        type: string
+        description: Email of the invitee
+      invited_by:
+        type: string
+        description: Email of the person that created the invitation
+      organizations:
+        type: array
+        description: List of organizations that the invitee will be added to
+        items:
+          type: string
+      status:
+        type: string
+        description: The status of the invitation. Either 'pending', 'accepted', or 'expired'
+
+  V4CreateInvitationRequest:
+    type: object
+    required:
+      - email
+    properties:
+      account_expiry_days:
+        type: integer
+        description: The number of days after which the account should expire. Defaults to '0', which means never expire
+      email:
+        type: string
+        description: The email of the person you want to invite
+      organizations:
+        type: array
+        description: List of organizations that the invitee will be added to
+        items:
+          type: string
+      send_email:
+        type: boolean
+        description: Wether or not to send the invitee an email. Defaults to true
+
+  V4CreateInvitationResponse:
+    type: object
+    properties:
+      account_expiry_days:
+        type: integer
+        description: The number of days after which the account should expire
+      created:
+        type: string
+        description: Date/Time that the invitation was accepted
+      email:
+        type: string
+        description: Email of the invitee
+      invitation_accept_link:
+        type: string
+        description: A link that can be used to accept the invitation.
+      invited_by:
+        type: string
+        description: Email of the person that created the invitation
+      organizations:
+        type: array
+        description: List of organizations that the invitee will be added to
+        items:
+          type: string
+      status:
+        type: string
+        description: The status of the invitation. Either 'pending', 'accepted', or 'expired'
+

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -670,7 +670,7 @@ definitions:
   # The list of all invitations.
   V4InvitationsResponse:
     type: array
-    description: List of members that belong to this organization
+    description: List of all invitations in the system
     items:
       $ref: '#/definitions/V4Invitation'
 
@@ -719,7 +719,7 @@ definitions:
           type: string
       send_email:
         type: boolean
-        description: Wether or not to send the invitee an email. Defaults to true
+        description: Whether or not to send the invitee an email. Defaults to true
 
   V4CreateInvitationResponse:
     type: object
@@ -729,7 +729,7 @@ definitions:
         description: The number of days after which the account should expire
       created:
         type: string
-        description: Date/Time that the invitation was accepted
+        description: Date/Time that the invitation was created
       email:
         type: string
         description: Email of the invitee
@@ -744,6 +744,3 @@ definitions:
         description: List of organizations that the invitee will be added to
         items:
           type: string
-      status:
-        type: string
-        description: The status of the invitation. Either 'pending', 'accepted', or 'expired'

--- a/spec.yaml
+++ b/spec.yaml
@@ -259,7 +259,7 @@ paths:
         "200":
           description: Success
           schema:
-            $ref: "./definitions.yaml#/definitions/V4CreateInvitationResponse"
+            $ref: "./definitions.yaml#/definitions/V4Invitation"
           examples:
             application/json:
               {

--- a/spec.yaml
+++ b/spec.yaml
@@ -172,7 +172,7 @@ paths:
         - invitations
       summary: Get invitations
       description: |
-        Returns a list of invitations that are either pending or have been accepted.
+        Returns a list of invitations that are either pending, expired, or have been accepted.
         Both admins and users see the full list of invitations.
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
@@ -260,8 +260,7 @@ paths:
                 "email": "another-developer@giantswarm.io",
                 "invitation_accept_link": "http://happa-base-uri/signup/TeeChMCmgWym1uic",
                 "invited_by": "developer@giantswarm.io",
-                "organizations": ["giantswarm"],
-                "status": "pending"
+                "organizations": ["giantswarm"]
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"

--- a/spec.yaml
+++ b/spec.yaml
@@ -204,7 +204,7 @@ paths:
                   "invited_by": "developer@giantswarm.io",
                   "organizations": ["giantswarm"],
                   "status": "expired"
-                }
+                },
                 {
                   "accepted": "2018-08-03T13:32:23.000000",
                   "created": "2018-08-02T12:21:55.467700",

--- a/spec.yaml
+++ b/spec.yaml
@@ -188,21 +188,32 @@ paths:
             application/json:
               [
                 {
-                  "accepted": "",
+                  "accepted": null,
                   "created": "2018-08-02T12:21:55.467700",
                   "email": "bob@giantswarm.io",
+                  "expiry": "2018-08-05T12:21:55.467700",
                   "invited_by": "developer@giantswarm.io",
                   "organizations": ["giantswarm"],
                   "status": "pending"
                 },
                 {
+                  "accepted": null,
+                  "created": "2018-07-02T12:21:55.467700",
+                  "email": "dan@giantswarm.io",
+                  "expiry": "2018-07-05T12:21:55.467700",
+                  "invited_by": "developer@giantswarm.io",
+                  "organizations": ["giantswarm"],
+                  "status": "expired"
+                }
+                {
                   "accepted": "2018-08-03T13:32:23.000000",
                   "created": "2018-08-02T12:21:55.467700",
                   "email": "charles@giantswarm.io",
+                  "expiry": "2018-08-05T12:21:55.467700",
                   "invited_by": "developer@giantswarm.io",
                   "organizations": ["giantswarm"],
                   "status": "accepted"
-                }
+                },
               ]
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"

--- a/spec.yaml
+++ b/spec.yaml
@@ -242,10 +242,10 @@ paths:
           x-examples:
             application/json:
               {
-                  email: "another-developer@giantswarm.io",
-                  organizations: ["giantswarm"],
-                  send_email: true,
-                  account_expiry_days: 30,
+                account_expiry_days: 30,
+                email: "another-developer@giantswarm.io",
+                organizations: ["giantswarm"],
+                send_email: true,
               }
       responses:
         "200":

--- a/spec.yaml
+++ b/spec.yaml
@@ -189,7 +189,6 @@ paths:
               [
                 {
                   "accepted": "",
-                  "account_expiry_days": 1000,
                   "created": "2018-08-02T12:21:55.467700",
                   "email": "bob@giantswarm.io",
                   "invited_by": "developer@giantswarm.io",
@@ -198,7 +197,6 @@ paths:
                 },
                 {
                   "accepted": "2018-08-03T13:32:23.000000",
-                  "account_expiry_days": 1000,
                   "created": "2018-08-02T12:21:55.467700",
                   "email": "charles@giantswarm.io",
                   "invited_by": "developer@giantswarm.io",
@@ -242,7 +240,6 @@ paths:
           x-examples:
             application/json:
               {
-                account_expiry_days: 30,
                 email: "another-developer@giantswarm.io",
                 organizations: ["giantswarm"],
                 send_email: true,
@@ -255,7 +252,6 @@ paths:
           examples:
             application/json:
               {
-                "account_expiry_days": 1000,
                 "created": "2018-08-02T12:21:55.467700",
                 "email": "another-developer@giantswarm.io",
                 "invitation_accept_link": "http://happa-base-uri/signup/TeeChMCmgWym1uic",

--- a/spec.yaml
+++ b/spec.yaml
@@ -223,7 +223,7 @@ paths:
         will include the invitation_accept_link, which will never be shown again.
         The link is also not stored and should only be shared with the intended recipient.
 
-        The recipient will be sent a email with a link they can click to accept
+        The recipient will be sent an email with a link they can click to accept
         the invitation by default. You can set send_email to false to disable this.
 
         Only admins may invite users to organizations that they are not a member of.

--- a/spec.yaml
+++ b/spec.yaml
@@ -165,6 +165,111 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v4/invitations/:
+    get:
+      operationId: getInvitations
+      tags:
+        - invitations
+      summary: Get invitations
+      description: |
+        Returns a list of invitations that are either pending or have been accepted.
+        Both admins and users see the full list of invitations.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: Invitations
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4InvitationsResponse"
+          examples:
+            application/json:
+              [
+                {
+                  "accepted": "",
+                  "account_expiry_days": 1000,
+                  "created": "2018-08-02T12:21:55.467700",
+                  "email": "bob@giantswarm.io",
+                  "invited_by": "developer@giantswarm.io",
+                  "organizations": ["giantswarm"],
+                  "status": "pending"
+                },
+                {
+                  "accepted": "2018-08-03T13:32:23.000000",
+                  "account_expiry_days": 1000,
+                  "created": "2018-08-02T12:21:55.467700",
+                  "email": "charles@giantswarm.io",
+                  "invited_by": "developer@giantswarm.io",
+                  "organizations": ["giantswarm"],
+                  "status": "accepted"
+                }
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    post:
+      operationId: createInvitation
+      tags:
+        - invitations
+      summary: Create invitation
+      description: |
+        Use this endpoint to invite someone to your installation. The response
+        will include the invitation_accept_link, which will never be shown again.
+        The link is also not stored and should only be shared with the intended recipient.
+
+        The recipient will be sent a email with a link they can click to accept
+        the invitation by default. You can set send_email to false to disable this.
+
+        Only admins may invite users to organizations that they are not a member of.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - name: body
+          in: body
+          required: true
+          description: Create Invitation Request
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateInvitationRequest"
+          x-examples:
+            application/json:
+              {
+                  email: "another-developer@giantswarm.io",
+                  organizations: ["giantswarm"],
+                  send_email: true,
+                  account_expiry_days: 30,
+              }
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateInvitationResponse"
+          examples:
+            application/json:
+              {
+                "account_expiry_days": 1000,
+                "created": "2018-08-02T12:21:55.467700",
+                "email": "another-developer@giantswarm.io",
+                "invitation_accept_link": "http://happa-base-uri/signup/TeeChMCmgWym1uic",
+                "invited_by": "developer@giantswarm.io",
+                "organizations": ["giantswarm"],
+                "status": "pending"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
   /v4/auth-tokens/:
     post:
       operationId: createAuthToken


### PR DESCRIPTION
This adds the spec for inviting users (POST /v4/invitations/)
As well as a way of inspecting the invitations made so far (GET /v4/invitations/)

This goes towards: https://github.com/giantswarm/giantswarm/issues/3831 and https://github.com/giantswarm/giantswarm/issues/3965

Up next would be a way to actually accept the invitation (POST /v4/invitations/:token/)
And a way to validate the invitation token so that clients can provide some feedback early in the process (GET /v4/invitations/:token/)