### PR TITLE
Expose BYOC credential details

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ validate: spec-tmp.yaml lint
 	# Useful to ensure gsclientgen client generation works
 	@echo "Validating with go-swagger"
 	docker run --rm -it \
-	  -v ${PWD}:/workdir \
+		-v ${PWD}:/workdir \
 		-w /workdir \
 		quay.io/goswagger/swagger:0.16.0 \
 			validate spec-tmp.yaml

--- a/Makefile
+++ b/Makefile
@@ -25,20 +25,21 @@ lint: spec-tmp.yaml
 
 # Validate the swagger/OAI spec
 validate: spec-tmp.yaml lint
+	
+	# Useful to ensure gsclientgen client generation works
+	@echo "Validating with go-swagger"
+	docker run --rm -it \
+	  -v ${PWD}:/workdir \
+		-w /workdir \
+		quay.io/goswagger/swagger:0.16.0 \
+			validate spec-tmp.yaml
+
 	@echo "Generating swagger representation"
 	docker run --rm -it \
 		-v $(shell pwd):/code/yaml \
 		jimschubert/swagger-codegen-cli:${SWAGGER_VERSION} generate \
 		--input-spec /code/yaml/spec-tmp.yaml \
 		--lang swagger --output /tmp/
-
-	@echo "Generating static HTML documentation"
-	docker run --rm -it \
-		-v $(shell pwd):/code/yaml \
-		-v $(shell pwd)/html:/code/html \
-		jimschubert/swagger-codegen-cli:${SWAGGER_VERSION} generate \
-		--input-spec /code/yaml/spec-tmp.yaml \
-		--lang html --output /code/html
 
 	@echo "Generating JavaScript client code for test purposes"
 	docker run --rm -it \

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -136,6 +136,9 @@ definitions:
       name:
         type: string
         description: Cluster name
+      credentials_id:
+        type: string
+        description: ID of the credentials used to operate the cluster (only on AWS and Azure)
       release_version:
         type: string
         description: |

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -656,6 +656,9 @@ definitions:
     type: object
     description: Response model for getting details on a set of credentials
     properties:
+      id:
+        type: string
+        description: Unique ID of the credentials
       provider:
         type: string
         description: Either 'aws' or 'azure'

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -694,6 +694,16 @@ definitions:
                 type: string
                 description: Tenant ID of the Azure subscription
 
+  # response model for a list of credentials
+  V4GetCredentialsResponse:
+    type: array
+    description: |
+      List of credential sets for an organization. As of now, this can contain
+      either zero or one items.
+    items:
+      $ref: '#/definitions/V4GetCredentialResponse'
+ 
+
   # A request for an auth token
   V4CreateAuthTokenRequest:
     type: object

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -12,7 +12,7 @@ definitions:
         description: |
           A machine readable [response code](https://github.com/giantswarm/api-spec/blob/master/details/RESPONSE_CODES.md) like e. g. `INVALID_CREDENTIALS`
 
-  # Info resposne
+  # Info response
   V4InfoResponse:
     type: object
     properties:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -702,7 +702,6 @@ definitions:
       either zero or one items.
     items:
       $ref: '#/definitions/V4GetCredentialResponse'
- 
 
   # A request for an auth token
   V4CreateAuthTokenRequest:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -138,12 +138,13 @@ definitions:
         description: Cluster name
       credentials_id:
         type: string
-        description: ID of the credentials used to operate the cluster (only on AWS and Azure)
+        description: |
+          ID of the credentials used to operate the cluster (only on AWS and
+          Azure). See [Set credentials](#operation/addCredentials) for details.
       release_version:
         type: string
         description: |
-          The [release](https://docs.giantswarm.io/api/#tag/releases) version
-          currently running this cluster.
+          The [release](#tag/releases) version currently running this cluster.
       kubernetes_version:
         type: string
         description: Deprecated. Will be removed in a future API version.
@@ -644,6 +645,45 @@ definitions:
               secret_key:
                 type: string
                 description: Secret key of the service principal
+              subscription_id:
+                type: string
+                description: Azure subscription ID
+              tenant_id:
+                type: string
+                description: Tenant ID of the Azure subscription
+
+  V4GetCredentialResponse:
+    type: object
+    description: Response model for getting details on a set of credentials
+    properties:
+      provider:
+        type: string
+        description: Either 'aws' or 'azure'
+      aws:
+        type: object
+        description: Credentials specific to an AWS account
+        properties:
+          roles:
+            type: object
+            descriptions: IAM roles to assume by certain entities
+            properties:
+              admin:
+                type: string
+                description: ARN of the IAM role Giant Swarm support staff will use
+              awsoperator:
+                type: string
+                description: ARN of the IAM role assumed by the software operating clusters
+      azure:
+        type: object
+        description: Credentials specific to an Azure service principal
+        properties:
+          credential:
+            type: object
+            descriptions: Service principal credential
+            properties:
+              client_id:
+                type: string
+                description: Client ID of the service principal
               subscription_id:
                 type: string
                 description: Azure subscription ID

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -98,7 +98,6 @@ definitions:
 
   V4ModifyClusterRequest:
     type: object
-    required: []
     description: Request body for cluster modification
     properties:
       name:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -612,7 +612,7 @@ definitions:
         properties:
           roles:
             type: object
-            descriptions: IAM roles to assume by certain entities
+            description: IAM roles to assume by certain entities
             required:
               - awsoperator
               - admin
@@ -631,7 +631,7 @@ definitions:
         properties:
           credential:
             type: object
-            descriptions: Service principal credential
+            description: Service principal credential
             required:
               - client_id
               - secret_key
@@ -667,7 +667,7 @@ definitions:
         properties:
           roles:
             type: object
-            descriptions: IAM roles to assume by certain entities
+            description: IAM roles to assume by certain entities
             properties:
               admin:
                 type: string
@@ -681,7 +681,7 @@ definitions:
         properties:
           credential:
             type: object
-            descriptions: Service principal credential
+            description: Service principal credential
             properties:
               client_id:
                 type: string

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -135,7 +135,7 @@ definitions:
       name:
         type: string
         description: Cluster name
-      credentials_id:
+      credential_id:
         type: string
         description: |
           ID of the credentials used to operate the cluster (only on AWS and

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -674,7 +674,7 @@ definitions:
                 description: ARN of the IAM role Giant Swarm support staff will use
               awsoperator:
                 type: string
-                description: ARN of the IAM role assumed by the software operating clusters
+                description: ARN of the IAM role assumed by the software operating the clusters
       azure:
         type: object
         description: Credentials specific to an Azure service principal

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -20,8 +20,7 @@ parameters:
     in: path
     required: true
     type: string
-    description: |
-      Unique ID of a credential set
+    description: Unique ID of a credential set
 
   UserEmailPathParameter:
     name: email

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -16,7 +16,7 @@ parameters:
     description: Cluster ID
 
   CredentialsIdPathParameter:
-    name: credentials_id
+    name: credential_id
     in: path
     required: true
     type: string

--- a/parameters.yaml
+++ b/parameters.yaml
@@ -5,7 +5,8 @@ parameters:
     type: string
     in: header
     required: true
-    description: As described in the [authentication](#section/Authentication) section
+    description: |
+      As described in the [authentication](#section/Authentication) section
 
   ClusterIdPathParameter:
     name: cluster_id
@@ -13,6 +14,14 @@ parameters:
     required: true
     type: string
     description: Cluster ID
+
+  CredentialsIdPathParameter:
+    name: credentials_id
+    in: path
+    required: true
+    type: string
+    description: |
+      Unique ID of a credential set
 
   UserEmailPathParameter:
     name: email

--- a/spec.yaml
+++ b/spec.yaml
@@ -1247,6 +1247,46 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/organizations/{organization_id}/credentials/:
+    get:
+      operationId: getCredentials
+      tags:
+        - organizations
+      summary:
+        - Get credentials
+      description: |
+        Returns credentials for an organization, if available.
+        For more information on credentials,
+        see [Set credentials](#operation/addCredentials).
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: './parameters.yaml#/parameters/OrganizationIdPathParameter'
+      responses:
+        "200":
+          description: Credentials
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetCredentialsResponse"
+          examples:
+            application/json:
+              [
+                {
+                  "id": "a1b2c3",
+                  "provider": "azure",
+                  "azure": {
+                    "credential": {
+                      "client_id": "c93bf55e-5bf7-4966-ad2b-e6f6e7721d50",
+                      "subscription_id": "b388b7c7-4479-4040-9ac5-1e13edd6b1cd",
+                      "tenant_id": "3dd2e94a-92ba-434c-99be-32bb65864a99"
+                    }
+                  }
+                }
+              ]
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
     post:
       operationId: addCredentials
       tags:

--- a/spec.yaml
+++ b/spec.yaml
@@ -682,6 +682,7 @@ paths:
                 "release_version": "2.5.16",
                 "kubernetes_version": "",
                 "owner": "acme",
+                "credentials_id": "a1b2c",
                 "workers": [
                   {
                     "memory": {"size_gb": 2.0},

--- a/spec.yaml
+++ b/spec.yaml
@@ -1259,7 +1259,7 @@ paths:
 
         Here is another paragraph.
 
-        ### Example response for AWS
+        ### Example response body for AWS
 
         ```json
         [
@@ -1276,7 +1276,7 @@ paths:
         ]
         ```
 
-        ### Example response for Azure
+        ### Example response body for Azure
 
         ```json
         [
@@ -1436,6 +1436,38 @@ paths:
         ID. The returned data does not contain any secrets (i. e.
         passphrase, secret key). For more information on credentials, see
         [Set credentials](#operation/addCredentials).
+
+        ### Example response body for AWS
+
+        ```json
+        {
+          "id": "a1b2c3",
+          "provider": "aws",
+          "aws": {
+            "roles": {
+              "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
+              "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+            }
+          }
+        }
+        ```
+
+        ### Example response body for Azure
+
+        ```json
+        {
+          "id": "a1b2c3",
+          "provider": "azure",
+          "azure": {
+            "credential": {
+              "client_id": "c93bf55e-5bf7-4966-ad2b-e6f6e7721d50",
+              "subscription_id": "b388b7c7-4479-4040-9ac5-1e13edd6b1cd",
+              "tenant_id": "3dd2e94a-92ba-434c-99be-32bb65864a99"
+            }
+          }
+        }
+        ```
+
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'

--- a/spec.yaml
+++ b/spec.yaml
@@ -1389,7 +1389,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
-  /v4/organizations/{organization_id}/credentials/{credentials_id/}:
+  /v4/organizations/{organization_id}/credentials/{credentials_id}/:
     get:
       operationId: getCredential
       tags:

--- a/spec.yaml
+++ b/spec.yaml
@@ -1256,6 +1256,43 @@ paths:
         Returns credentials for an organization, if available.
         For more information on credentials,
         see [Set credentials](#operation/addCredentials).
+
+        Here is another paragraph.
+
+        ### Example response for AWS
+
+        ```json
+        [
+          {
+            "id": "a1b2c3",
+            "provider": "aws",
+            "aws": {
+              "roles": {
+                "admin": "arn:aws:iam::123456789012:role/GiantSwarmAdmin",
+                "awsoperator": "arn:aws:iam::123456789012:role/GiantSwarmAWSOperator"
+              }
+            }
+          }
+        ]
+        ```
+
+        ### Example response for Azure
+
+        ```json
+        [
+          {
+            "id": "a1b2c3",
+            "provider": "azure",
+            "azure": {
+              "credential": {
+                "client_id": "c93bf55e-5bf7-4966-ad2b-e6f6e7721d50",
+                "subscription_id": "b388b7c7-4479-4040-9ac5-1e13edd6b1cd",
+                "tenant_id": "3dd2e94a-92ba-434c-99be-32bb65864a99"
+              }
+            }
+          }
+        ]
+        ```
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'

--- a/spec.yaml
+++ b/spec.yaml
@@ -1267,7 +1267,7 @@ paths:
         "200":
           description: Credentials
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GetCredentialsResponse"
+            $ref: './definitions.yaml#/definitions/V4GetCredentialsResponse'
           examples:
             application/json:
               [
@@ -1286,7 +1286,7 @@ paths:
         default:
           description: error
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+            $ref: './definitions.yaml#/definitions/V4GenericResponse'
     post:
       operationId: addCredentials
       tags:
@@ -1340,12 +1340,12 @@ paths:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
-        - $ref: "./parameters.yaml#/parameters/OrganizationIdPathParameter"
+        - $ref: './parameters.yaml#/parameters/OrganizationIdPathParameter'
         - name: body
           in: body
           required: true
           schema:
-            $ref: "./definitions.yaml#/definitions/V4AddCredentialsRequest"
+            $ref: './definitions.yaml#/definitions/V4AddCredentialsRequest'
           x-examples:
             application/json:
               {
@@ -1365,7 +1365,7 @@ paths:
               type: string
               description: URI of the new credentials resource
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+            $ref: './definitions.yaml#/definitions/V4GenericResponse'
           examples:
             application/json:
               {
@@ -1373,11 +1373,11 @@ paths:
                 "message": "A new set of credentials has been created with ID '5d9h4'"
               }
         "401":
-          $ref: "./responses.yaml#/responses/V4Generic401Response"
+          $ref: './responses.yaml#/responses/V4Generic401Response'
         "409":
           description: Conflict
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+            $ref: './definitions.yaml#/definitions/V4GenericResponse'
           examples:
             application/json:
               {
@@ -1387,7 +1387,7 @@ paths:
         default:
           description: error
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+            $ref: './definitions.yaml#/definitions/V4GenericResponse'
 
   /v4/organizations/{organization_id}/credentials/{credentials_id}/:
     get:

--- a/spec.yaml
+++ b/spec.yaml
@@ -1376,6 +1376,7 @@ paths:
           examples:
             application/json:
               {
+                "id": "a1b2c3",
                 "provider": "azure",
                 "azure": {
                   "credential": {

--- a/spec.yaml
+++ b/spec.yaml
@@ -1349,6 +1349,47 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v4/organizations/{organization_id}/credentials/{credentials_id/}:
+    get:
+      operationId: getCredential
+      tags:
+        - organizations
+      summary:
+        - Get credential details
+      description: |
+        Returns details for a particular set of credentials, identified by its
+        ID. The returned data does not contain any secrets (i. e.
+        passphrase, secret key). For more information on credentials, see
+        [Set credentials](#operation/addCredentials).
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: './parameters.yaml#/parameters/OrganizationIdPathParameter'
+        - $ref: './parameters.yaml#/parameters/CredentialsIdPathParameter'
+      responses:
+        "200":
+          description: Credentials details
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetCredentialResponse"
+          examples:
+            application/json:
+              {
+                "provider": "azure",
+                "azure": {
+                  "credential": {
+                    "client_id": "c93bf55e-5bf7-4966-ad2b-e6f6e7721d50",
+                    "subscription_id": "b388b7c7-4479-4040-9ac5-1e13edd6b1cd",
+                    "tenant_id": "3dd2e94a-92ba-434c-99be-32bb65864a99"
+                  }
+                }
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
   /v4/releases/:
     get:
       operationId: getReleases

--- a/spec.yaml
+++ b/spec.yaml
@@ -1251,8 +1251,7 @@ paths:
       operationId: getCredentials
       tags:
         - organizations
-      summary:
-        - Get credentials
+      summary: Get credentials
       description: |
         Returns credentials for an organization, if available.
         For more information on credentials,
@@ -1394,8 +1393,7 @@ paths:
       operationId: getCredential
       tags:
         - organizations
-      summary:
-        - Get credential details
+      summary: Get credential details
       description: |
         Returns details for a particular set of credentials, identified by its
         ID. The returned data does not contain any secrets (i. e.

--- a/spec.yaml
+++ b/spec.yaml
@@ -682,7 +682,7 @@ paths:
                 "release_version": "2.5.16",
                 "kubernetes_version": "",
                 "owner": "acme",
-                "credentials_id": "a1b2c",
+                "credential_id": "a1b2c",
                 "workers": [
                   {
                     "memory": {"size_gb": 2.0},
@@ -1425,7 +1425,7 @@ paths:
           schema:
             $ref: './definitions.yaml#/definitions/V4GenericResponse'
 
-  /v4/organizations/{organization_id}/credentials/{credentials_id}/:
+  /v4/organizations/{organization_id}/credentials/{credential_id}/:
     get:
       operationId: getCredential
       tags:


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3987

This PR adds functions to fetch details about the credentials in use for a cluster in AWS or Azure.

- `getCluster` (`GET /v4/clusters/{cluster_id}/`) response now also contains the `credentials_id` key
- new operation `getCredentials` (`GET /v4/organizations/{organization_id}/credentials/`) to fetch credentials of an organization
- new operation `getCredential` (`GET /v4/organizations/{organization_id}/credentials/{credentials_id}/`) to fetch credentials