### PR TITLE
Render HTML statically using redoc-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,18 @@
-FROM node:10 as builder
+FROM node:8-slim as builder
 
-WORKDIR /
-RUN git clone --depth 1 https://github.com/Rebilly/ReDoc.git
+RUN npm -v
+RUN npm install redoc
 
-WORKDIR /ReDoc/cli
-RUN npm install -g
-RUN npm run
-RUN find / -type f -name "redoc-cli"
-RUN which redoc-cli
-
-ADD *.yaml /ReDoc/cli/
-RUN redoc-cli bundle spec.yaml
+ADD *.yaml /
+RUN npx redoc-cli bundle spec.yaml
 RUN ls -la
 
 FROM nginx:stable-alpine
 RUN rm -r /etc/nginx/conf.d
-#ADD docserver/index.html /www/
-#ADD *.yaml /www/yaml/
-
-#RUN mkdir /www/js
-#ADD https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js /www/js/redoc.min.js
-#RUN chmod 0644 /www/js/redoc.min.js
-
 ADD docserver/nginx.conf /etc/nginx/
+
+COPY --from=builder /redoc-static.html /www/index.html
+RUN chmod 0644 /www/*
+
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,26 @@
-FROM nginx:1.14-alpine
-RUN rm -r /etc/nginx/conf.d
-ADD docserver/index.html /www/
-ADD *.yaml /www/yaml/
+FROM node:10 as builder
 
-RUN mkdir /www/js
-ADD https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js /www/js/redoc.min.js
-RUN chmod 0644 /www/js/redoc.min.js
+WORKDIR /
+RUN git clone --depth 1 https://github.com/Rebilly/ReDoc.git
+
+WORKDIR /ReDoc/cli
+RUN npm install -g
+RUN npm run
+RUN find / -type f -name "redoc-cli"
+RUN which redoc-cli
+
+ADD *.yaml /ReDoc/cli/
+RUN redoc-cli bundle spec.yaml
+RUN ls -la
+
+FROM nginx:stable-alpine
+RUN rm -r /etc/nginx/conf.d
+#ADD docserver/index.html /www/
+#ADD *.yaml /www/yaml/
+
+#RUN mkdir /www/js
+#ADD https://rebilly.github.io/ReDoc/releases/latest/redoc.min.js /www/js/redoc.min.js
+#RUN chmod 0644 /www/js/redoc.min.js
 
 ADD docserver/nginx.conf /etc/nginx/
 


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/3626

This replaces the current single-page JavaScript application rendering our API docs based on the swaggger YAML with a HTML + minimal JavaScript version.

The benefits are on the SEO and loading speed side, as well as in usability for slower devices. However the final result isn't as polished as the one we currently have. I am also worried that the template or CSS used diverges from ReDoc's master and will lag behind when it comes to improvements.

See for yourself by running

```
make run-server
```

and then open http://localhost:8080/

Preview

![image](https://user-images.githubusercontent.com/273727/44913828-c03b1b00-ad2e-11e8-8e21-486182361031.png)
