### PR TITLE
Add icons to HTML

### DIFF
--- a/docserver/index.html
+++ b/docserver/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <title>Giant Swarm API</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" type="image/x-icon" href="https://giantswarm.io/static/img/favicon32.ico">
+    <link rel="shortcut icon" type="image/x-icon" href="https://giantswarm.io/static/img/favicon32.ico">
+    <link rel="icon" sizes="152x152" href="https://giantswarm.io/static/img/icon_152x152.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="https://giantswarm.io/static/img/icon_152x152.png">
     <style>
       body {
         margin: 0;


### PR DESCRIPTION
This adds a shortcut icon and more to the API spec HTML output, using the same ones we have in the documentation site.