### PR TITLE
Add /v4/info/app-catalog/

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -658,3 +658,59 @@ definitions:
       auth_token:
         type: string
         description: The newly created API token
+
+  V4AppCatalogResponse:
+    type: array
+    items:
+      $ref: '#/definitions/V4AppCatalogItem'
+
+  V4AppCatalogItem:
+    type: object
+    properties:
+      name:
+        type: string
+        description: Unique identifier for this app
+      title:
+        type: string
+        description: User friendly name of this app
+      description:
+        type: string
+        description: A description of what this app this
+      logo_url:
+        type: string
+        description: A url pointing to an image that can be used as an icon or logo for this app
+      screenshots:
+        type: array
+        items:
+          type: object
+          properties:
+            url:
+              type: string
+              description: A url pointing to a screenshot of the app
+            caption:
+              type: string
+              description: A caption describing the screenshot
+      versions:
+        type: array
+        items:
+          type: object
+          properties:
+            version:
+              type: string
+              description: Version number
+            changelog:
+              description: |
+                Structured list of changes in this release, in comparison to the
+                previous version, with respect to the contained components.
+              type: array
+              items:
+                type: object
+                properties:
+                  component:
+                    type: string
+                    description: |
+                      If the changed item was a component, this attribute is the
+                      name of the component.
+                  description:
+                    type: string
+                    description: Human-friendly description of the change

--- a/spec.yaml
+++ b/spec.yaml
@@ -186,7 +186,31 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4AppCatalogResponse"
           examples:
             application/json:
-              []
+              [
+                {
+                  "name": "prometheus",
+                  "title": "Prometheus Monitoring Stack",
+                  "description": "",
+                  "logo_url": "",
+                  "screenshots": [
+                    {
+                      "url": "",
+                      "caption": ""
+                    },
+                  ],
+                  "versions": [
+                    {
+                      "version": "",
+                      "changelog": [
+                        {
+                        "component": "",
+                        "description": ""
+                        }
+                      ],
+                    }
+                  ]
+                }
+              ]
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:

--- a/spec.yaml
+++ b/spec.yaml
@@ -203,8 +203,8 @@ paths:
                       "version": "",
                       "changelog": [
                         {
-                        "component": "",
-                        "description": ""
+                          "component": "",
+                          "description": ""
                         }
                       ],
                     }

--- a/spec.yaml
+++ b/spec.yaml
@@ -165,6 +165,35 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v4/info/app-catalog/:
+    get:
+      operationId: getAppCatalog
+      tags:
+        - info
+      summary: Get the app catalog
+      description: |
+        Returns a list of applications that can be installed on tenant clusters.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+      responses:
+        "200":
+          description: App Catalog
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4AppCatalogResponse"
+          examples:
+            application/json:
+              []
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
   /v4/auth-tokens/:
     post:
       operationId: createAuthToken


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/4331

This is the spec for the listing of available apps that our apps can eventually use to show users a friendly browsable overview of available apps.