### PR TITLE
add availability zones

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -104,7 +104,7 @@ definitions:
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           to use in the new cluster
       availability_zones:
-        description: Number of availability zones a cluster should be spread across.
+        description: Number of availability zones a cluster should be spread across. The default is provided via the [info](#operation/getInfo) endpoint.
         type: integer
       workers:
         type: array

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -66,7 +66,7 @@ definitions:
                   type: object
                   properties:
                     cidr_blocks:
-                      description: List of CIDRs that will be used by services in Kubernetes
+                      description: List of CIDR blocks that will be used by services in Kubernetes
                       type: array
                       items:
                         type: string

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -39,58 +39,6 @@ definitions:
               default:
                 description: Default number of availability zones for a cluster.
                 type: number
-      network:
-        description: Information related to networking in the clusters
-        type: object
-        properties:
-          ranges:
-            description: IP ranges that can be used by clusters
-            type: array
-            items:
-              type: object
-              properties:
-                name:
-                  description: Name of the IP range (e. g.  "production" or "default")
-                  type: string
-                pods:
-                  description: IP ranges for pods
-                  type: object
-                  properties:
-                    cidr_blocks:
-                      description: List of CIDRs that will be used by pods
-                      type: array
-                      items:
-                        type: string
-                services:
-                  description: IP ranges for services in Kubernetes
-                  type: object
-                  properties:
-                    cidr_blocks:
-                      description: List of CIDR blocks that will be used by services in Kubernetes
-                      type: array
-                      items:
-                        type: string
-                docker:
-                  description: IP ranges for docker
-                  type: object
-                  properties:
-                    cidr_blocks:
-                      description: List of CIDRs that will be used by docker on the nodes
-                      type: array
-                      items:
-                        type: string
-                clusters:
-                  description: IP ranges for clusters.
-                  type: object
-                  properties:
-                    cidr_blocks:
-                      description: List of CIDRs that are available to create clusters.
-                      type: array
-                      items:
-                        type: string
-                    cidr_mask:
-                      description: Mask that is used to cut slices of the cidr_blocks for an individual cluster.
-                      type: number
       workers:
         description: Information related to worker nodes
         type: object

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -34,7 +34,7 @@ definitions:
             description: Number of availability zones which a cluster can be spread across.
             properties:
               max:
-                description: Maximum number of availability zones in this region.
+                description: Number of availability zones in the region of this installation.
                 type: number
               default:
                 description: Default number of availability zones for a cluster.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -50,7 +50,7 @@ definitions:
               type: object
               properties:
                 name:
-                  description: Name of the IP range (eg production or default)
+                  description: Name of the IP range (e. g.  "production" or "default")
                   type: string
                 pods:
                   description: IP ranges for pods

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -31,7 +31,7 @@ definitions:
             type: string
           availability_zones:
             type: object
-            description: Number of availability zones that the cluster can be spread across.
+            description: Number of availability zones which a cluster can be spread across.
             properties:
               max:
                 description: Maximum number of availability zones in this region.

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -29,6 +29,68 @@ definitions:
           datacenter:
             description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
             type: string
+          availability_zones:
+            type: object
+            description: Number of availability zones that the cluster can be spread across.
+            properties:
+              max:
+                description: Maximum number of availability zones in this region.
+                type: number
+              default:
+                description: Default number of availability zones for a cluster.
+                type: number
+      network:
+        description: Information related to networking in the clusters
+        type: object
+        properties:
+          ranges:
+            description: IP ranges that can be used by clusters
+            type: array
+            items:
+              type: object
+              properties:
+                name:
+                  description: Name of the IP range (eg production or default)
+                  type: string
+                pods:
+                  description: IP ranges for pods
+                  type: object
+                  properties:
+                    cidr_blocks:
+                      description: List of CIDRs that will be used by pods
+                      type: array
+                      items:
+                        type: string
+                services:
+                  description: IP ranges for services in Kubernetes
+                  type: object
+                  properties:
+                    cidr_blocks:
+                      description: List of CIDRs that will be used by services in Kubernetes
+                      type: array
+                      items:
+                        type: string
+                docker:
+                  description: IP ranges for docker
+                  type: object
+                  properties:
+                    cidr_blocks:
+                      description: List of CIDRs that will be used by docker on the nodes
+                      type: array
+                      items:
+                        type: string
+                clusters:
+                  description: IP ranges for clusters.
+                  type: object
+                  properties:
+                    cidr_blocks:
+                      description: List of CIDRs that are available to create clusters.
+                      type: array
+                      items:
+                        type: string
+                    cidr_mask:
+                      description: Mask that is used to cut slices of the cidr_blocks for an individual cluster.
+                      type: number
       workers:
         description: Information related to worker nodes
         type: object
@@ -86,6 +148,9 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           to use in the new cluster
+      availability_zones:
+        description: Number of availability zones a cluster should be spread across.
+        type: number
       workers:
         type: array
         items:
@@ -140,6 +205,9 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           currently running this cluster.
+      availability_zones:
+        description: Number of availability zones a cluster is spread across.
+        type: number
       workers:
         type: array
         items:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -42,10 +42,10 @@ definitions:
             properties:
               max:
                 description: Number of availability zones in the region of this installation.
-                type: number
+                type: integer
               default:
                 description: Default number of availability zones for a cluster.
-                type: number
+                type: integer
       workers:
         description: Information related to worker nodes
         type: object
@@ -105,7 +105,7 @@ definitions:
           to use in the new cluster
       availability_zones:
         description: Number of availability zones a cluster should be spread across.
-        type: number
+        type: integer
       workers:
         type: array
         items:
@@ -162,7 +162,7 @@ definitions:
           currently running this cluster.
       availability_zones:
         description: Number of availability zones a cluster is spread across.
-        type: number
+        type: integer
       workers:
         type: array
         items:

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -15,10 +15,14 @@ definitions:
   # Info response
   V4InfoResponse:
     type: object
+    required:
+      - general
     properties:
       general:
         description: General information
         type: object
+        required:
+          - availability_zones
         properties:
           installation_name:
             description: Unique name of the installation
@@ -32,6 +36,9 @@ definitions:
           availability_zones:
             type: object
             description: Number of availability zones which a cluster can be spread across.
+            required:
+              - max
+              - default
             properties:
               max:
                 description: Number of availability zones in the region of this installation.

--- a/spec.yaml
+++ b/spec.yaml
@@ -628,7 +628,7 @@ paths:
         IP range example:
 
         If a cluster gets a `/22` range (1022 hosts) and the cluster should be
-        spawned across 3 availability zones. The range will then be split up
+        spawned across 3 availability zones, the range will then be split up
         into four `/24` (254 hosts) that can be assigned to four different
         availability zones. One range will stay unused because network
         addresses must be powers of two. See [CIDR addressing](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).

--- a/spec.yaml
+++ b/spec.yaml
@@ -623,19 +623,21 @@ paths:
 
         IP range example:
 
-        If a cluster gets a `/22` (1022 hosts). And the cluster should be
+        If a cluster gets a `/22` (1022 hosts) and the cluster should be
         spawned across 3 availability zones. The range will then be split up
         into four `/24` (254 hosts) that can be given to four different
-        availability zones. One range will be stay unused because ranges can
-        only be split binary. Each of the `/24` will then be split into two
-        `/25` (126 hosts) for public and private subnets. The private subnet is
-        used for nodes and internal loadbalancer (only if you create them
-        within Kubernetes). The public subnet will be used by the public
-        loadbalancers. Your cluster comes with two public loadbalancers already.
-        One for the Kubernetes API and one for Ingress.
+        availability zones. One range will be stay unused because network
+        addresses must be powers of two. See [CIDR addressing](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
+        Each of the `/24` will then be split into two `/25` (126 hosts) for
+        public and private subnets. The private subnet is used for nodes and
+        internal loadbalancer (only if you create them within Kubernetes). The
+        public subnet will be used by the public loadbalancers. Tenant cluster
+        come with two public loadbalancers by default. One for the Kubernetes API
+        and one for Ingress.
 
         __Note:__ AWS ELBs can take up to 8 IP addresses due to the way how
-        they scale.
+        they scale. In addition to this, every AWS subnet has four first
+        addresses (.1-.4) reserved for internal use.
 
         The `workers` attribute, if present, must contain an array of node
         definition objects. The number of objects given determines the number

--- a/spec.yaml
+++ b/spec.yaml
@@ -911,7 +911,7 @@ paths:
         ### Limitations
 
         - As of now, existing worker nodes cannot be modified.
-        - The number of availability zones can not be changed afterwards.
+        - The number of availability zones cannot be modified afterwards.
         - When removing nodes (scaling down), it is not possible to determine
         which nodes will be removed.
         - On AWS based clusters, all worker nodes must use the same EC2 instance

--- a/spec.yaml
+++ b/spec.yaml
@@ -629,7 +629,7 @@ paths:
 
         If a cluster gets a `/22` (1022 hosts) and the cluster should be
         spawned across 3 availability zones. The range will then be split up
-        into four `/24` (254 hosts) that can be given to four different
+        into four `/24` (254 hosts) that can be assigned to four different
         availability zones. One range will stay unused because network
         addresses must be powers of two. See [CIDR addressing](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
         Each of the `/24` will then be split into two `/25` (126 hosts) for

--- a/spec.yaml
+++ b/spec.yaml
@@ -630,7 +630,7 @@ paths:
         If a cluster gets a `/22` (1022 hosts) and the cluster should be
         spawned across 3 availability zones. The range will then be split up
         into four `/24` (254 hosts) that can be given to four different
-        availability zones. One range will be stay unused because network
+        availability zones. One range will stay unused because network
         addresses must be powers of two. See [CIDR addressing](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing).
         Each of the `/24` will then be split into two `/25` (126 hosts) for
         public and private subnets. The private subnet is used for nodes and

--- a/spec.yaml
+++ b/spec.yaml
@@ -627,7 +627,7 @@ paths:
 
         IP range example:
 
-        If a cluster gets a `/22` (1022 hosts) and the cluster should be
+        If a cluster gets a `/22` range (1022 hosts) and the cluster should be
         spawned across 3 availability zones. The range will then be split up
         into four `/24` (254 hosts) that can be assigned to four different
         availability zones. One range will stay unused because network

--- a/spec.yaml
+++ b/spec.yaml
@@ -623,7 +623,7 @@ paths:
         that can be created in the cluster. The number of availability zones
         splits the IP range that can be used for the cluster in multiple smaller
         IP ranges. The [getInfo](#operation/getInfo) endpoint provides more
-        details about the cluster ip range.
+        details about the cluster IP range.
 
         IP range example:
 

--- a/spec.yaml
+++ b/spec.yaml
@@ -622,7 +622,7 @@ paths:
         The number of `availability_zones` affects the total number of nodes
         that can be created in the cluster. The number of availability zones
         splits the IP range that can be used for the cluster in multiple smaller
-        ip ranges. The [getInfo](#operation/getInfo) endpoint provides more
+        IP ranges. The [getInfo](#operation/getInfo) endpoint provides more
         details about the cluster ip range.
 
         IP range example:

--- a/spec.yaml
+++ b/spec.yaml
@@ -93,7 +93,29 @@ paths:
           "general": {
             "installation_name": "shire",
             "provider": "aws",
-            "datacenter": "eu-central-1"
+            "datacenter": "eu-central-1",
+            "availability_zones": {
+              "max": 3,
+              "default": 1,
+            }
+          },
+          "network": {
+            "ranges": [{
+              "name": "default",
+              "pods": {
+                "cidr_blocks": ["192.168.0.0/16"]
+              },
+              "services": {
+                "cidr_blocks": ["172.31.0.0/16"]
+              },
+              "docker": {
+                "cidr_blocks": ["172.17.0.1/16"]
+              },
+              "clusters": {
+                "cidr_blocks": ["10.1.0.0/16"],
+                "cidr_mask": 24
+              }
+            }],
           },
           "workers": {
             "count_per_cluster": {
@@ -117,7 +139,29 @@ paths:
           "general": {
             "installation_name": "isengard",
             "provider": "kvm",
-            "datacenter": "string"
+            "datacenter": "string",
+            "availability_zones": {
+              "max": 1,
+              "default": 1,
+            }
+          },
+          "network": {
+            "ranges": [{
+              "name": "default",
+              "pods": {
+                "cidr_blocks": ["192.168.0.0/16"]
+              },
+              "services": {
+                "cidr_blocks": ["172.31.0.0/16"]
+              },
+              "docker": {
+                "cidr_blocks": ["172.17.0.1/16"]
+              },
+              "clusters": {
+                "cidr_blocks": ["10.1.0.0/16"],
+                "cidr_mask": 24
+              }
+            }],
           },
           "workers": {
             "count_per_cluster": {
@@ -143,7 +187,29 @@ paths:
                 "general": {
                   "installation_name": "shire",
                   "provider": "aws",
-                  "datacenter": "eu-central-1"
+                  "datacenter": "eu-central-1",
+                  "availability_zones": {
+                    "max": 3,
+                    "default": 1
+                  }
+                },
+                "network": {
+                  "ranges": [{
+                    "name": "default",
+                    "pods": {
+                      "cidr_blocks": ["192.168.0.0/16"]
+                    },
+                    "services": {
+                      "cidr_blocks": ["172.31.0.0/16"]
+                    },
+                    "docker": {
+                      "cidr_blocks": ["172.17.0.1/16"]
+                    },
+                    "clusters": {
+                      "cidr_blocks": ["10.1.0.0/16"],
+                      "cidr_mask": 24
+                    }
+                  }],
                 },
                 "workers": {
                   "count_per_cluster": {
@@ -560,13 +626,15 @@ paths:
                   "id": "g8s3o",
                   "create_date": "2017-06-08T12:31:47.215Z",
                   "name": "Staging Cluster",
-                  "owner": "acme"
+                  "owner": "acme",
+                  "availability_zones": 2
                 },
                 {
                   "id": "3dkr6",
                   "create_date": "2017-05-22T13:58:02.024Z",
                   "name": "Test Cluster",
-                  "owner": "testorg"
+                  "owner": "testorg",
+                  "availability_zones": 1
                 }
               ]
         "401":
@@ -601,6 +669,28 @@ paths:
         omitted, default configuration values will be applied. For example, if
         no `release_version` is specified, the most recent version is used.
 
+        The number of `availability_zones` affects the total number of nodes
+        that can be created in the cluster. The number of availability zones
+        splits the ip range that can be used for the cluster in multiple smaller
+        ip ranges. The [getInfo](#operation/getInfo) endpoint provides more
+        details about the cluster ip range.
+
+        IP range example:
+
+        If a cluster gets a `/22` (1022 hosts). And the cluster should be
+        spawned across 3 availability zones. The range will then be split up
+        into four `/24` (254 hosts) that can be given to four different
+        availability zones. One range will be stay unused because ranges can
+        only be split binary. Each of the `/24` will then be split into two
+        `/25` (126 hosts) for public and private subnets. The private subnet is
+        used for nodes and internal loadbalancer (only if you create them
+        within Kubernetes). The public subnet will be used by the public
+        loadbalancers. Your cluster comes with two public loadbalancers already.
+        One for the Kubernetes API and one for Ingress.
+
+        __Note:__ AWS ELBs can take up to 8 IP addresses due to the way how
+        they scale.
+
         The `workers` attribute, if present, must contain an array of node
         definition objects. The number of objects given determines the number
         of workers created.
@@ -629,6 +719,7 @@ paths:
                 "owner": "myteam",
                 "release_version": "1.4.2",
                 "name": "Example cluster with 3 default worker nodes",
+                "availability_zones": 2,
                 "workers": [{}, {}, {}]
               }
       responses:
@@ -682,6 +773,7 @@ paths:
                 "release_version": "2.5.16",
                 "owner": "acme",
                 "credential_id": "a1b2c",
+                "availability_zones": 1,
                 "workers": [
                   {
                     "memory": {"size_gb": 2.0},
@@ -819,6 +911,7 @@ paths:
         ### Limitations
 
         - As of now, existing worker nodes cannot be modified.
+        - The number of availability zones can not be changed afterwards.
         - When removing nodes (scaling down), it is not possible to determine
         which nodes will be removed.
         - On AWS based clusters, all worker nodes must use the same EC2 instance

--- a/spec.yaml
+++ b/spec.yaml
@@ -99,24 +99,6 @@ paths:
               "default": 1,
             }
           },
-          "network": {
-            "ranges": [{
-              "name": "default",
-              "pods": {
-                "cidr_blocks": ["192.168.0.0/16"]
-              },
-              "services": {
-                "cidr_blocks": ["172.31.0.0/16"]
-              },
-              "docker": {
-                "cidr_blocks": ["172.17.0.1/16"]
-              },
-              "clusters": {
-                "cidr_blocks": ["10.1.0.0/16"],
-                "cidr_mask": 24
-              }
-            }],
-          },
           "workers": {
             "count_per_cluster": {
               "max": null,
@@ -144,24 +126,6 @@ paths:
               "max": 1,
               "default": 1,
             }
-          },
-          "network": {
-            "ranges": [{
-              "name": "default",
-              "pods": {
-                "cidr_blocks": ["192.168.0.0/16"]
-              },
-              "services": {
-                "cidr_blocks": ["172.31.0.0/16"]
-              },
-              "docker": {
-                "cidr_blocks": ["172.17.0.1/16"]
-              },
-              "clusters": {
-                "cidr_blocks": ["10.1.0.0/16"],
-                "cidr_mask": 24
-              }
-            }],
           },
           "workers": {
             "count_per_cluster": {
@@ -192,24 +156,6 @@ paths:
                     "max": 3,
                     "default": 1
                   }
-                },
-                "network": {
-                  "ranges": [{
-                    "name": "default",
-                    "pods": {
-                      "cidr_blocks": ["192.168.0.0/16"]
-                    },
-                    "services": {
-                      "cidr_blocks": ["172.31.0.0/16"]
-                    },
-                    "docker": {
-                      "cidr_blocks": ["172.17.0.1/16"]
-                    },
-                    "clusters": {
-                      "cidr_blocks": ["10.1.0.0/16"],
-                      "cidr_mask": 24
-                    }
-                  }],
                 },
                 "workers": {
                   "count_per_cluster": {

--- a/spec.yaml
+++ b/spec.yaml
@@ -621,7 +621,7 @@ paths:
 
         The number of `availability_zones` affects the total number of nodes
         that can be created in the cluster. The number of availability zones
-        splits the ip range that can be used for the cluster in multiple smaller
+        splits the IP range that can be used for the cluster in multiple smaller
         ip ranges. The [getInfo](#operation/getInfo) endpoint provides more
         details about the cluster ip range.
 


### PR DESCRIPTION
clusters can have multiple availability zones now. to get a better
understanding on how this affects subnet ranges and cluster sizes the
info endpoint provides a bit more information about the configured ip
ranges in the installation. clients can then calculate the number of
nodes for the users.


Please make sure in case you are changing the spec all our customers are informed beforehand.

You can throw a message in #sig-customer with the changes and the Solution Engineers will take care of
sharing the changes with the customers.