### PR TITLE
Adds note to AuthorizationHeaderToken about SSO

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -65,6 +65,10 @@ securityDefinitions:
       header with a value of the format `giantswarm <token>`. Auth tokens can be
       obtained using the [createAuthToken](#operation/createAuthToken)
       operation.
+
+      For Giant Swarm staff who are authenticating using SSO,
+      pass the auth token via the `Authorization` header with a value of the
+      format `Bearer <token>`.
     type: apiKey
     name: Authorization
     in: header


### PR DESCRIPTION
This bit me earlier, it should be documented.

<img width="819" alt="screen shot 2018-11-07 at 14 14 22" src="https://user-images.githubusercontent.com/297653/48136391-71ae7d80-e297-11e8-88e4-51504f6f91b5.png">

becoming:

<img width="1291" alt="screen shot 2018-11-08 at 11 03 57" src="https://user-images.githubusercontent.com/297653/48194843-096aa500-e346-11e8-86af-30261430461f.png">
