### PR TITLE
add availability zone to cluster details and listing

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -161,8 +161,11 @@ definitions:
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           currently running this cluster.
       availability_zones:
-        description: Number of availability zones a cluster is spread across.
-        type: integer
+        description: List of availability zones a cluster is spread across.
+        type: array
+        items:
+          description: Name of the availability zone
+          type: string
       workers:
         type: array
         items:
@@ -523,6 +526,12 @@ definitions:
       owner:
         type: string
         description: Name of the organization owning the cluster
+      availability_zones:
+        description: List of availability zones a cluster is spread across.
+        type: array
+        items:
+          description: Name of the availability zone
+          type: string
       release_version:
         type: string
         description: The semantic version number of this cluster

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -526,12 +526,6 @@ definitions:
       owner:
         type: string
         description: Name of the organization owning the cluster
-      availability_zones:
-        description: List of availability zones a cluster is spread across.
-        type: array
-        items:
-          description: Name of the availability zone
-          type: string
       release_version:
         type: string
         description: The semantic version number of this cluster

--- a/details/CLUSTER_DEFINITION.md
+++ b/details/CLUSTER_DEFINITION.md
@@ -21,6 +21,7 @@ __Note:__ upon cluster creation, some of the attributes shown below MUST NOT be 
     "api_endpoint": "https://api.wqtlq.example.com",
     "name": "Just a Standard Cluster",
     "owner": "acme",
+    "availability_zones": ["fire-zone-1"],
     "release_version": "1.0.0",
     "workers": [
         {
@@ -59,6 +60,7 @@ This example here shows a cluster definition in JSON format, as it may be submit
 {
     "name": "A Cluster on AWS",
     "owner": "acme",
+    "availability_zones": 2,
     "workers": [
         {
             "aws": {
@@ -89,6 +91,7 @@ After creation using the definition above, the code below shows the completed cl
     "api_endpoint": "https://api.wqtlq.example.com",
     "name": "A Cluster on AWS",
     "owner": "acme",
+    "availability_zones": ["eu-central-1a", "eu-central-1b"],
     "release_version": "1.0.0",
     "workers": [
         {
@@ -133,6 +136,7 @@ After creation using the definition above, the code below shows the completed cl
 - `release_version`: The [release](https://docs.giantswarm.io/api/#tag/releases) version of the cluster
 - `name`: User friendly name of the cluster
 - `owner`: Name of the organization owning the cluster.
+- `availability_zones`: Upon creation this is an integer that defines in how many availability zones a cluster should be launched. If the cluster object is retrieved from the API it will contain an array of strings with the actual names of the availability zones.
 - `workers`: Array of worker definition objects. Each array item represents one worker node. In order to create a cluster with three worker nodes, this array MUST have three items, even if all worker share the same configuration.
 - `workers[n].aws.instance_type`: Name of the EC2 instance type to use for the worker node. For clusters running on AWS, this attribute is required on cluster creation and must have the same value for all worker nodes of the cluster.
 - `workers[n].memory`: Memory definition object. This object can currently contain only one attribute `size_gb`, which indicates the RAM size in Gigabytes as an integer. For clusters running on AWS, this attribute is ignored on cluster creation.

--- a/spec.yaml
+++ b/spec.yaml
@@ -577,14 +577,14 @@ paths:
                   "create_date": "2017-06-08T12:31:47.215Z",
                   "name": "Staging Cluster",
                   "owner": "acme",
-                  "availability_zones": 2
+                  "availability_zones": ["eu-west-1a", "eu-west-1c"]
                 },
                 {
                   "id": "3dkr6",
                   "create_date": "2017-05-22T13:58:02.024Z",
                   "name": "Test Cluster",
                   "owner": "testorg",
-                  "availability_zones": 1
+                  "availability_zones": ["eu-west-1b"]
                 }
               ]
         "401":
@@ -725,7 +725,7 @@ paths:
                 "release_version": "2.5.16",
                 "owner": "acme",
                 "credential_id": "a1b2c",
-                "availability_zones": 1,
+                "availability_zones": ["fire-zone-1"],
                 "workers": [
                   {
                     "memory": {"size_gb": 2.0},

--- a/spec.yaml
+++ b/spec.yaml
@@ -576,15 +576,13 @@ paths:
                   "id": "g8s3o",
                   "create_date": "2017-06-08T12:31:47.215Z",
                   "name": "Staging Cluster",
-                  "owner": "acme",
-                  "availability_zones": ["eu-west-1a", "eu-west-1c"]
+                  "owner": "acme"
                 },
                 {
                   "id": "3dkr6",
                   "create_date": "2017-05-22T13:58:02.024Z",
                   "name": "Test Cluster",
-                  "owner": "testorg",
-                  "availability_zones": ["eu-west-1b"]
+                  "owner": "testorg"
                 }
               ]
         "401":


### PR DESCRIPTION
respond with the actual list of availability zones of a cluster.


Please make sure in case you are changing the spec all our customers are informed beforehand.

You can throw a message in #sig-customer with the changes and the Solution Engineers will take care of
sharing the changes with the customers.