### PR TITLE
Improve readability of auth section

### DIFF
--- a/spec.yaml
+++ b/spec.yaml
@@ -62,9 +62,14 @@ securityDefinitions:
   AuthorizationHeaderToken:
     description: |
       Clients authenticate by passing an auth token via the `Authorization`
-      header with a value of the format `giantswarm <token>`. Auth tokens can be
-      obtained using the [createAuthToken](#operation/createAuthToken)
-      operation.
+      header with the format
+      
+      ```
+      Authorization: giantswarm <token>
+      ````
+      
+      Auth tokens can be obtained using the 
+      [createAuthToken](#operation/createAuthToken) operation.
 
       For Giant Swarm staff who are authenticating using SSO,
       pass the auth token via the `Authorization` header with a value of the


### PR DESCRIPTION
This should make it more obvious how the Authorization header works. By making the header a separate line, we want to prevent unfortunate line breaks in the code snippet.