### PR TITLE
Add info regarding scaling min=max

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -110,7 +110,8 @@ definitions:
         type: object
         description: |
           Attributes specific to cluster node scaling. To have full control of
-          the cluster size, min and max can be set to the same value.
+          the cluster size, min and max can be set to the same value. If only
+          `min` or only `max` is specified, `min` and `max` will be set equally.
         properties:
           min:
             type: integer


### PR DESCRIPTION
This adds an info how a missing `scalin.min` or `scaling.max` value will be treated.

From https://gigantic.slack.com/archives/C7865GLSY/p1547111558000800