### PR TITLE
Add region field for cluster

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -103,6 +103,9 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           to use in the new cluster
+      region:
+        description: Region where tenant cluster should be created. The default is the same region where Giant Swarm control plane is running.
+        type: string
       availability_zones:
         description: Number of availability zones a cluster should be spread across. The default is provided via the [info](#operation/getInfo) endpoint.
         type: integer
@@ -206,6 +209,9 @@ definitions:
             type: integer
             description: |
               The maximum number of cluster nodes as configured
+      region:
+        type: string
+        description: Region where this cluster is running at.
       availability_zones:
         description: List of availability zones a cluster is spread across.
         type: array

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -211,7 +211,7 @@ definitions:
               The maximum number of cluster nodes as configured
       region:
         type: string
-        description: Region where this cluster is running at.
+        description: Name of the region where this cluster is running at.
       availability_zones:
         description: List of availability zones a cluster is spread across.
         type: array


### PR DESCRIPTION
In order to be able to create inter-region clusters in AWS, a region field must
be present for cluster object.

Please make sure in case you are changing the spec all our customers are informed beforehand.

You can throw a message in #sig-customer with the changes and the Solution Engineers will take care of
sharing the changes with the customers.

