### PR TITLE
List tenant cluster apps.

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -284,6 +284,52 @@ definitions:
         type: object
         additionalProperties: true
 
+  V4GetClusterAppsResponse:
+    type: array
+    description: Array of apps
+    items:
+      type: object
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The identifier you set when creating this app
+        spec:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the chart that was used to install this app
+            namespace:
+              type: string
+              description: The namespace that this app is installed to
+            version:
+              type: string
+              description: The version of the chart that was used to install this app
+            catalog:
+              type: string
+              description: The catalog that this app came from
+        status:
+          type: object
+          properties:
+            app_version:
+              type: string
+              description: The version of the installed app
+            version:
+              type: string
+              description: The version of the chart that was used to install this app
+            release:
+              type: object
+              properties:
+                last_deployed:
+                  type: string
+                  description: Date and time that the app was last last deployed
+                status:
+                  type: string
+                  description: "A string representing the status of the app. (Can be: empty, DEPLOYED or FAILED)"
+
   V4GetClusterStatusResponse:
     type: object
     description: Object about a cluster's current state

--- a/spec.yaml
+++ b/spec.yaml
@@ -1088,6 +1088,14 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v4/clusters/{cluster_id}/apps/:
+    get:
+      operationId: getClusterApps
+      tags:
+        - app katalog
+        - cluster
+      summary: Get cluster apps
+
   /v4/organizations/:
     get:
       operationId: getOrganizations

--- a/spec.yaml
+++ b/spec.yaml
@@ -1093,8 +1093,27 @@ paths:
       operationId: getClusterApps
       tags:
         - app katalog
-        - cluster
+        - clusters
       summary: Get cluster apps
+      description: |
+        Returns an array of apps installed on a given cluster.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      responses:
+        "200":
+          description: Cluster apps
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppsResponse"
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/organizations/:
     get:

--- a/spec.yaml
+++ b/spec.yaml
@@ -1092,8 +1092,7 @@ paths:
     get:
       operationId: getClusterApps
       tags:
-        - app katalog
-        - clusters
+        - managed apps
       summary: Get cluster apps
       description: |
         Returns an array of apps installed on a given cluster.
@@ -1107,19 +1106,19 @@ paths:
               },
 
               "spec": {
+                "catalog": "sample-catalog"
                 "name": "prometheus-chart",
                 "namespace": "giantswarm",
-                "version": "0.2.0",
-                "catalog": "sample-catalog"
+                "version": "0.2.0"
               },
 
               "status": {
                 "app_version": "1.0.0",
-                "version": "0.2.0",
                 "release": {
                   "last_deployed": "2019-04-08T12:34:00Z",
                   "status": "DEPLOYED"
-                }
+                },
+                "version": "0.2.0",
               }
             }
           ]
@@ -1144,19 +1143,19 @@ paths:
                   },
 
                   "spec": {
+                    "catalog": "sample-catalog",
                     "name": "prometheus-chart",
                     "namespace": "giantswarm",
-                    "version": "0.2.0",
-                    "catalog": "sample-catalog"
+                    "version": "0.2.0"
                   },
 
                   "status": {
                     "app_version": "1.0.0",
-                    "version": "0.2.0",
                     "release": {
                       "last_deployed": "2019-04-08T12:34:00Z",
                       "status": "DEPLOYED"
-                    }
+                    },
+                    "version": "0.2.0"
                   }
                 }
               ]

--- a/spec.yaml
+++ b/spec.yaml
@@ -1097,6 +1097,33 @@ paths:
       summary: Get cluster apps
       description: |
         Returns an array of apps installed on a given cluster.
+
+        ### Example
+        ```json
+          [
+            {
+              "metadata": {
+                "name": "my-awesome-prometheus",
+              },
+
+              "spec": {
+                "name": "prometheus-chart",
+                "namespace": "giantswarm",
+                "version": "0.2.0",
+                "catalog": "sample-catalog"
+              },
+
+              "status": {
+                "app_version": "1.0.0",
+                "version": "0.2.0",
+                "release": {
+                  "last_deployed": "2019-04-08T12:34:00Z",
+                  "status": "DEPLOYED"
+                }
+              }
+            }
+          ]
+        ```
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
@@ -1108,6 +1135,31 @@ paths:
           description: Cluster apps
           schema:
             $ref: "./definitions.yaml#/definitions/V4GetClusterAppsResponse"
+          examples:
+            application/json:
+              [
+                {
+                  "metadata": {
+                    "name": "my-awesome-prometheus",
+                  },
+
+                  "spec": {
+                    "name": "prometheus-chart",
+                    "namespace": "giantswarm",
+                    "version": "0.2.0",
+                    "catalog": "sample-catalog"
+                  },
+
+                  "status": {
+                    "app_version": "1.0.0",
+                    "version": "0.2.0",
+                    "release": {
+                      "last_deployed": "2019-04-08T12:34:00Z",
+                      "status": "DEPLOYED"
+                    }
+                  }
+                }
+              ]
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:


### PR DESCRIPTION
This PR proposes a way to fetch the apps that are installed on a given tenant cluster.

FYI @giantswarm/sig-ux : Operations can have multiple tags, so it will show up in the `Cluster` category as well as the `App Katalog` category in api docs.

That seems desirable to me since I would personally expect to see it in both places. But opinions are welcome here.