### PR TITLE
Reduce yamllint warnings

### DIFF
--- a/yamllint/config.yaml
+++ b/yamllint/config.yaml
@@ -3,7 +3,7 @@ extends: default
 rules:
   # don't fail if line is longer than 80 characters
   line-length:
-    max: 80
+    max: 120
     level: warning
 
   # don't warn about missing "---" at beginning


### PR DESCRIPTION
This increases the line length limit from 80 to 120 characters.

80 is very limiting and sometimes not achievable when there are e. g. URLs in a line.

As a result, we currently get far less warnings, which makes actual errors easier to find and maybe increases the likelihood that warnings are mitigated, too.