### PR TITLE
Import webfonts, apply Inconsolata to attribute names

### DIFF
--- a/docserver/index.html
+++ b/docserver/index.html
@@ -16,7 +16,12 @@
       .redoc-json a {
         color: #6793f5 !important;
       }
+
+      pre, .param-name-wrap, .param-name-wrap[_ngcontent-c12] {
+        font-family: Iconsolata, monospace !important;
+      }
     </style>
+    <link rel="stylesheet" type="text/css" href="//fonts.googleapis.com/css?family=Roboto+Slab:300,700|Roboto:300,700,300italic|Inconsolata:400,700">
   </head>
   <body>
     <redoc spec-url='yaml/spec.yaml'></redoc>


### PR DESCRIPTION
This adds importing webfonts, which we were trying to use so far, but weren't added to the page.

Also adds a little improvement on the rendering of attribute names

### Before

![image](https://user-images.githubusercontent.com/273727/57370456-78f40c80-7190-11e9-9eac-d49719d49697.png)

### Now

![image](https://user-images.githubusercontent.com/273727/57370408-637ee280-7190-11e9-82dd-831dc500a0cf.png)
