### PR TITLE
Fix V4AppCatalogsResponse schema

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -19,29 +19,33 @@ definitions:
       type: object
       properties:
         metadata:
-          name:
-            description: A URL friendly identifier for the catalog.
-            type: string
+          type: object
+          properties:
+            name:
+              description: A URL friendly identifier for the catalog.
+              type: string
         spec:
-          title:
-            description: A display friendly title for this catalog.
-            type: string
-          description:
-            description: A description of the catalog.
-            type: string
-          logoURL:
-            description: A URL to a logo representing this catalog.
-            type: string
-          storage:
-            description: Contains information on where to find the full catalog, and what type of catalog it is.
-            type: object
-            properties:
-              URL:
-                description: A URL where clients can download the full catalog.
-                type: string
-              type:
-                description: The format of this catalog. (Currently only helm is supported.)
-                type: string
+          type: object
+          properties:
+            title:
+              description: A display friendly title for this catalog.
+              type: string
+            description:
+              description: A description of the catalog.
+              type: string
+            logoURL:
+              description: A URL to a logo representing this catalog.
+              type: string
+            storage:
+              description: Contains information on where to find the full catalog, and what type of catalog it is.
+              type: object
+              properties:
+                URL:
+                  description: A URL where clients can download the full catalog.
+                  type: string
+                type:
+                  description: The format of this catalog. (Currently only helm is supported.)
+                  type: string
 
   # Info response
   V4InfoResponse:


### PR DESCRIPTION
Fixes the `V4AppCatalogsResponse` schema.

Unfortunately, our `validate` step in CI didn't catch this. We'll have to improve that, too.