### PR TITLE
Get app config

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -428,6 +428,11 @@ definitions:
     items:
       $ref: '#/definitions/V4App'
 
+  V4GetClusterAppConfigResponse:
+    type: object
+    description: The values configmap for a given app returned as a yaml file
+    additionalProperties: true
+
   V4CreateAppConfigRequest:
     type: object
     description: A part of the App CR that we create behind the scenes

--- a/spec.yaml
+++ b/spec.yaml
@@ -1433,6 +1433,50 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/clusters/{cluster_id}/apps/{app_name}/config/:
+    get:
+      operationId: getClusterAppConfig
+      tags:
+        - apps
+      summary: Get app config
+      description: |
+        This operation allows you to fetch the user values configmap associated
+        with an app.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppConfigResponse"
+          examples:
+            appication/json:
+              {
+                "agent": {
+                  "key": "secret-key-here",
+                  "endpointHost": "saas-eu-west-1.instana.io",
+                  "endpointPort": "443",
+                },
+                "zone": {
+                  "name": "giantswarm-cluster"
+                }
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Unable to show app config. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
+              }
     put:
       operationId: createClusterAppConfig
       tags:


### PR DESCRIPTION
Hey @giantswarm/team-batman @giantswarm/sig-ux 

I'm implementing a way to upload a values.yaml file for an app so that users can configure their app.

The AppCR spec has a reference to a configmap by name. This can be any name. That means at first sight an endpoint like `/v4/clusters/{cluster_id}/configs/{config_name}/` is the way to go. 

However that has some disadvantages. Instead I am going with `/v4/clusters/{cluster_id}/apps/{app_name}/config/`. 

In this endpoint the configmap does not get a user definable name, even though, using kubectl, a user could create a configmap for the purposes of app configuration and give it whatever name they please.

The idea here is that on `POST` when a user uses the API to create such a configmap, the name will follow a strict convention. However on `GET` the API will still be able to deal with configmaps that are not named according to that convention by first fetching the App Cr, looking up the name of the configmap, and then finding the configmap and returning it to the user.

Below is my thinking about the two possibilities:

```
1. GET/POST: /v4/clusters/{cluster_id}/configs/{config_name}/

  Advantage: No convention enforced for how values configmaps are named.
             We look at the config_name path param and can know which config to fetch.

  Disadvantage: If implemented naively, this allows people to see any configmap
                in the cluster namespace as well as create a configmap with
                any name in that namespace.

                To guard against that we'd have to fetch every App CR and make sure that config_name 
                is mentioned in one of them.

2. /v4/clusters/{cluster_id}/apps/{app_name}/config/

  Advantage: The name of the config is not up to the user. So we can create a
             configmap by some name convention.

  Disadvantage: It's possible for someone to make a valid app using kubectl
                that does not meet the convention.

                However, the endpoint could deal with this. i.e. when fetching an app
                config for display it could ignore the convention and look
                up the configmap based on what is in the App CR.

                Adds complexity to the endpoint.

  GET Psuedocode:
                1. Fetch the App CR
                2. Look into the `userConfig.configMap.name` field.
                3. Get that configmap and return it.

  POST Psuedocode:
                1. Check if an app with app_name exists,
                
                If it exists:
                  1. Check if it has a `userConfig.configMap.name` field.
                  2. If it does, error? (Resource already exists)
                  3. If it doesn't, create a configmap with a name by convention, possibly:
                     `appname-user-values`

                If it doesn't exist:
                  1. Create a configmap with name by convention (`appname-user-values`)

```

Lastly, I'm not sure how to return an object that could have any schema. For that reason, I am choosing to return the yaml as a file. I think that should work out fine, though I can do some further digging in the swagger docs to see if I can return some kind of 'schema less' json object.

Will be merged into: https://github.com/giantswarm/api-spec/pull/143