### PR TITLE
Add stats to info response

### DIFF
--- a/definitions.yaml
+++ b/definitions.yaml
@@ -81,6 +81,23 @@ definitions:
               default:
                 description: Default number of availability zones for a cluster.
                 type: integer
+      stats:
+        type: object
+        description: Statistics about the installation
+        properties:
+          cluster_creation_duration:
+            type: object
+            description: Duration of cluster creation, summarized.
+            properties:
+              median:
+                type: integer
+                description: Median of the value distribution
+              p25:
+                type: integer
+                description: 75th percentile of the value distribution
+              p75:
+                type: integer
+                description: 75th percentile of the value distribution
       workers:
         description: Information related to worker nodes
         type: object

--- a/spec.yaml
+++ b/spec.yaml
@@ -173,6 +173,13 @@ paths:
               "default": 1,
             }
           },
+          "stats": {
+            "cluster_creation_duration": {
+              "median": 750,
+              "p25": 700,
+              "p75": 800
+            }
+          },
           "workers": {
             "count_per_cluster": {
               "max": null,
@@ -199,6 +206,13 @@ paths:
             "availability_zones": {
               "max": 1,
               "default": 1,
+            }
+          },
+          "stats": {
+            "cluster_creation_duration": {
+              "median": 750,
+              "p25": 700,
+              "p75": 800
             }
           },
           "workers": {
@@ -229,6 +243,13 @@ paths:
                   "availability_zones": {
                     "max": 3,
                     "default": 1
+                  }
+                },
+                "stats": {
+                  "cluster_creation_duration": {
+                    "median": 750,
+                    "p25": 700,
+                    "p75": 800
                   }
                 },
                 "workers": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6005

This enables the API to expose statistical informtion regarding the installation via the `GET /v4/info/` endpoint.

The only statistic currently supported is `cluster_creation_duration`, which is the duration of cluster ceation, in seconds.