### PR TITLE
Add spec for modifying apps and app configs.

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -373,8 +373,6 @@ definitions:
           version:
             type: string
             description: Version of the chart that should be used to install this app
-          user_config:
-            $ref: '#/definitions/V4AppSpecUserConfigConfigMap'
 
   V4App:
     type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -360,8 +360,6 @@ definitions:
           catalog:
             type: string
             description: The catalog where the chart for this app can be found
-          user_config:
-            $ref: '#/definitions/V4AppSpecUserConfigConfigMap'
 
   V4ModifyAppRequest:
     type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -363,6 +363,19 @@ definitions:
           user_config:
             $ref: '#/definitions/V4AppSpecUserConfigConfigMap'
 
+  V4ModifyAppRequest:
+    type: object
+    description: The fields that are editable when trying to modify an app
+    properties:
+      spec:
+        type: object
+        properties:
+          version:
+            type: string
+            description: Version of the chart that should be used to install this app
+          user_config:
+            $ref: '#/definitions/V4AppSpecUserConfigConfigMap'
+
   V4App:
     type: object
     properties:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -45,6 +45,8 @@ tags:
       description: "User guide: Accessing Pods and Services from the Outside"
   - name: apps
     description: "An app is a helm chart that you can easily install on your tenant clusters. Use these endpoints to: find out what catalogs your installation supports, and list and install apps on on your tenant clusters."
+  - name: app configs
+    description: "Creating an app config lets you supply your apps with custom configuration values."
   - name: organizations
     description: Organizations are groups of users who own resources like clusters.
   - name: users
@@ -1436,7 +1438,7 @@ paths:
       operationId: modifyClusterApp
       tags:
         - apps
-      summary: Modify app
+      summary: Modify an app
       description: |
         This operation allows you to modify an existing app.
 
@@ -1444,7 +1446,7 @@ paths:
 
         - `version`: Changing this field lets you upgrade or downgrade an app.
 
-        `catalog`, `name`, `namespace`, and 'user_config' are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
+        `catalog`, `name`, `namespace`, and `user_config` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
         Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
@@ -1502,7 +1504,7 @@ paths:
     get:
       operationId: getClusterAppConfig
       tags:
-        - apps
+        - app configs
       summary: Get app config
       description: |
         This operation allows you to fetch the user values configmap associated
@@ -1546,7 +1548,7 @@ paths:
     put:
       operationId: createClusterAppConfig
       tags:
-        - apps
+        - app configs
       summary: Create app config
       description: |
         This operation allows you to create a values configmap for a specific app. The app does
@@ -1630,7 +1632,7 @@ paths:
     delete:
       operationId: deleteClusterAppConfig
       tags:
-        - apps
+        - app configs
       summary: Delete an app config
       description: |
         This operation allows a user to delete an app's user config if it has been named according to the convention of {app-name}-user-values and
@@ -1680,7 +1682,7 @@ paths:
     patch:
       operationId: modifyClusterAppConfig
       tags:
-        - apps
+        - app configs
       summary: Modify app config
       description: |
         This operation allows you to modify the values configmap for a specific app.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1432,6 +1432,89 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+    patch:
+      operationId: modifyApp
+      tags:
+        - apps
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAppRequest"
+          x-examples:
+            application/json:
+              {
+                "spec": {
+                  "catalog": "sample-catalog",
+                  "name": "prometheus-chart",
+                  "namespace": "prometheus",
+                  "version": "0.2.0",
+                  "user_config": {
+                    "configmap": {
+                      "name": "prometheus-user-values",
+                      "namespace": "123ab"
+                    }
+                  }
+                }
+              }
+
+      summary: Modify app
+      description: |
+        This operation allows you to modify an existing app.
+
+        The following attributes can be modified:
+
+        - `user_config`: This lets you change the configmap used to configure this app, as well as remove it entirely, by submitting empty values.
+        - `version`: Changing this field lets you upgrade or downgrade an app.
+
+        `catalog`, `name`, and `namespace` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+
+        The full request must be valid before it will be executed, currently this
+        means every member you attempt to add to the organization must actually
+        exist in the system. If any member you attempt to add is invalid, the entire
+        patch operation will fail, no members will be added or removed, and an error message
+        will explain which members in your request are invalid.
+      responses:
+        "200":
+          description: App modified
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4App"
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The app could not be modified. (invalid input: name is not an editable field)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The app could not be modified. (not found: the app with name 'my-great-app' could not be found)"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
   /v4/clusters/{cluster_id}/apps/{app_name}/config/:
     get:
       operationId: getClusterAppConfig

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1355,8 +1355,10 @@ paths:
         correctly for you.
 
         ### Why can't I just set the `user_config` value myself?
-        This is a security measure and ensures that users of this API can't
-        access arbitrary configmaps of the control plane.
+        It simplifies usage while also being a security measure.
+
+        Furthermore it is also a security measure and ensures that users of this
+        API can't access arbitrary configmaps of the control plane.
 
         This API will only allow you to edit or access configmaps that adhere
         to a strict naming convention.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1442,10 +1442,9 @@ paths:
 
         The following attributes can be modified:
 
-        - `user_config`: This lets you change which configmap is used to configure this app, as well as remove it entirely, by submitting null values.
         - `version`: Changing this field lets you upgrade or downgrade an app.
 
-        `catalog`, `name`, and `namespace` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
+        `catalog`, `name`, `namespace`, and 'user_config' are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
 
         The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
         Requests have to be sent with the `Content-Type: application/merge-patch+json` header.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1326,7 +1326,6 @@ paths:
 
         To check on the status of your app, perform a GET to /v4/clusters/{cluster_id}/apps/,
         and check the status field of the app.
-        ###
 
         ### Example PUT request
         ```json
@@ -1336,15 +1335,32 @@ paths:
               "name": "prometheus-chart",
               "namespace": "prometheus",
               "version": "0.2.0",
-              "user_config": {
-                "configmap": {
-                  "name": "prometheus-user-values",
-                  "namespace": "123ab"
-                }
-              }
             }
           }
         ```
+
+        ### About the user_config field in the response
+        This field is not editable by you, but is set automatically by the API
+        if a configmap named `{app_name}-user-values` exists in the tenant cluster
+        namespace on the control plane.
+
+        The `/v4/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows
+        you to create such a configmap using this API.
+
+        It is recommended to create your config before creating your app. This
+        will result in a faster deploy.
+
+        However, you can create your config after creating the app if you wish,
+        this API will take care of setting the `user_config` field of the app
+        correctly for you.
+
+        ### Why can't I just set the `user_config` value myself?
+        This is a security measure and ensures that users of this API can't
+        access arbitrary configmaps of the control plane.
+
+        This API will only allow you to edit or access configmaps that adhere
+        to a strict naming convention.
+
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
@@ -1364,12 +1380,6 @@ paths:
                   "name": "prometheus-chart",
                   "namespace": "prometheus",
                   "version": "0.2.0",
-                  "user_config": {
-                    "configmap": {
-                      "name": "prometheus-user-values",
-                      "namespace": "123ab"
-                    }
-                  }
                 }
               }
       responses:
@@ -1554,6 +1564,14 @@ paths:
         This operation allows you to create a values configmap for a specific app. The app does
         not have to exist before hand.
 
+        If the app does exist, this endpoint will ensure that the App CR gets it's
+        user_config field set correctly.
+
+        However, if the app exists and the user_config is already set to something,
+        then this request will fail. You will in that case most likely want to
+        update the config using the `PATCH /v4/clusters/{cluster_id}/apps/{app_name}/config/`
+        endpoint.
+
 
         ### Example POST request
         ```json
@@ -1689,8 +1707,8 @@ paths:
         It's only possible to modify app configs that have been named according to the convention of
         {app-name}-user-values and stored in the cluster ID namespace.
 
-        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
-        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+        The full values key of the configmap will be replaced by the JSON body
+        of your request.
 
         ### Example PATCH request
         ```json
@@ -1700,6 +1718,23 @@ paths:
             }
           }
         ```
+
+        If the configmap contained content like:
+
+        ```json
+          {
+            "agent": {
+              "key": "an-old-key-here",
+              "admin": true,
+            },
+            "server": {
+              "url": "giantswarm.io",
+            }
+          }
+        ```
+
+        Then the "server" and "admin" keys will be removed.
+
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
@@ -1712,7 +1747,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4CreateAppConfigRequest"
           x-examples:
-            application/merge-patch+json:
+            application/json:
               {
                 "agent": {
                   "key": "a-new-key-here",
@@ -1738,7 +1773,7 @@ paths:
             application/json:
               {
                 "code": "INVALID_INPUT",
-                "message": "App config could not be modified. (invalid input)"
+                "message": "App config could not be created. (invalid input)"
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1726,8 +1726,8 @@ paths:
           examples:
             appication/json:
               {
-                "code": "RESOURCE_CREATED",
-                "message": "App config for 'my-awesome-app' on 'abc12' has been created."
+                "code": "RESOURCE_UPDATED",
+                "message": "App config for 'my-awesome-app' on 'abc12' has been updated."
               }
         "400":
           description: Invalid input
@@ -1741,16 +1741,6 @@ paths:
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
-        "409":
-          description: App config already exists
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-          examples:
-            application/json:
-              {
-                "code": "RESOURCE_ALREADY_EXISTS",
-                "message": "A config for 'my-awesome-app' on 'abc12' already exists."
-              }
         default:
           description: Error
           schema:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1738,7 +1738,7 @@ paths:
             application/json:
               {
                 "code": "INVALID_INPUT",
-                "message": "App config could not be created. (invalid input)"
+                "message": "App config could not be modified. (invalid input)"
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1433,9 +1433,22 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyApp
+      operationId: modifyClusterApp
       tags:
         - apps
+      summary: Modify app
+      description: |
+        This operation allows you to modify an existing app.
+
+        The following attributes can be modified:
+
+        - `user_config`: This lets you change which configmap is used to configure this app, as well as remove it entirely, by submitting null values.
+        - `version`: Changing this field lets you upgrade or downgrade an app.
+
+        `catalog`, `name`, and `namespace` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
       parameters:
         - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
@@ -1446,43 +1459,14 @@ paths:
         - name: body
           in: body
           schema:
-            $ref: "./definitions.yaml#/definitions/V4CreateAppRequest"
+            $ref: "./definitions.yaml#/definitions/V4ModifyAppRequest"
           x-examples:
-            application/json:
+            application/merge-patch+json:
               {
                 "spec": {
-                  "catalog": "sample-catalog",
-                  "name": "prometheus-chart",
-                  "namespace": "prometheus",
-                  "version": "0.2.0",
-                  "user_config": {
-                    "configmap": {
-                      "name": "prometheus-user-values",
-                      "namespace": "123ab"
-                    }
-                  }
+                  "version": "0.3.0",
                 }
               }
-
-      summary: Modify app
-      description: |
-        This operation allows you to modify an existing app.
-
-        The following attributes can be modified:
-
-        - `user_config`: This lets you change the configmap used to configure this app, as well as remove it entirely, by submitting empty values.
-        - `version`: Changing this field lets you upgrade or downgrade an app.
-
-        `catalog`, `name`, and `namespace` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
-
-        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
-        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
-
-        The full request must be valid before it will be executed, currently this
-        means every member you attempt to add to the organization must actually
-        exist in the system. If any member you attempt to add is invalid, the entire
-        patch operation will fail, no members will be added or removed, and an error message
-        will explain which members in your request are invalid.
       responses:
         "200":
           description: App modified
@@ -1688,6 +1672,84 @@ paths:
               {
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The user config of app 'my-app' could not be deleted. ('my-app' not found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    patch:
+      operationId: modifyClusterAppConfig
+      tags:
+        - apps
+      summary: Modify app config
+      description: |
+        This operation allows you to modify the values configmap for a specific app.
+        It's only possible to modify app configs that have been named according to the convention of
+        {app-name}-user-values and stored in the cluster ID namespace.
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+
+        ### Example PATCH request
+        ```json
+          {
+            "agent": {
+              "key": "a-new-key-here",
+            }
+          }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAppConfigRequest"
+          x-examples:
+            application/merge-patch+json:
+              {
+                "agent": {
+                  "key": "a-new-key-here",
+                }
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            appication/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "App config for 'my-awesome-app' on 'abc12' has been created."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "App config could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: App config already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "A config for 'my-awesome-app' on 'abc12' already exists."
               }
         default:
           description: Error


### PR DESCRIPTION
This is a spec for the PATCH requests on the `app` and `app config` resources.

I made it so only the `user_config` and `version` fields of `app` are editable. I feel like changing the catalog, name, or namespace would probably be complex, not sure how the operators would react to that.

For the `app config`, as long as the configmap is named in the conventional way, users can change anything, using JSON merge patch semantics.