### PR TITLE
Combine details and status for v5 clusters

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -989,11 +989,6 @@ definitions:
             type: string
             description: |
               Name of the availability zone the master node is placed in
-
-  V5GetClusterStatusResponse:
-    type: object
-    description: Cluster status information
-    properties:
       conditions:
         type: array
         description: List of conditions the cluster has gone through

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2343,7 +2343,19 @@ paths:
                 "credential_id": "a1b2c",
                 "master": {
                   "availability_zone": "europe-west-1c"
-                }
+                },
+                "conditions": [
+                  {
+                    "last_transition_time": "2019-03-25T17:10:09.333633991Z",
+                    "condition": "Created"
+                  }
+                ],
+                "versions": [
+                  {
+                    "last_transition_time": "2019-03-25T17:10:09.333633991Z",
+                    "version": "1.2.3"
+                  }
+                ]
               }
         "301":
           description: Version mismatch
@@ -2756,66 +2768,6 @@ paths:
                 "code": "RESOURCE_NOT_FOUND",
                 "message": "The node pool with ID 'wqt' could not be found..."
               }
-        default:
-          description: error
-          schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
-
-  /v5/clusters/{cluster_id}/status/:
-    get:
-      operationId: getClusterStatusV5
-      tags:
-        - clusters
-      summary: Get cluster status
-      description: |
-        Returns an object about a cluster's current state and past status transitions.
-
-        __Providers__:
-        <span class="badge aws">AWS</span>
-        &ndash; Only supports release `TODO` and higher on AWS.
-
-        This endpoint exposes the status content of the Kubernetes resources representing
-        a cluster in the corresponding custom resource:
-
-        [`awsconfig.provider.giantswarm.io`](https://godoc.org/github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1#AWSConfig)
-
-        Note that structure and style differ from the rest of the v5 API. Also note that
-        the structure depends on the release version and changes can be expected frequently.
-
-        ## TODO
-
-        - Adapt the link above, as the current one is not correct
-        - Give response 200 example
-
-      parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
-        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
-        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
-        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
-        - $ref: './parameters.yaml#/parameters/ClusterIdPathParameter'
-      responses:
-        "200":
-          description: Cluster status
-          schema:
-            $ref: "./definitions.yaml#/definitions/V5GetClusterStatusResponse"
-          examples:
-            application/json:
-              {
-                "conditions": [
-                  {
-                    "last_transition_time": "2019-03-25T17:10:09.333633991Z",
-                    "condition": "Created"
-                  }
-                ],
-                "versions": [
-                  {
-                    "last_transition_time": "2019-03-25T17:10:09.333633991Z",
-                    "version": "1.2.3"
-                  }
-                ]
-              }
-        "401":
-          $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
           description: error
           schema:


### PR DESCRIPTION
To be merged into #130 

This is a change we discussed to not use a separate endpoint for clusters status, instead let the cluster details endpoint return the status into, too.