### PR TITLE
Node Pool Creation Validation

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -811,7 +811,7 @@ definitions:
     properties:
       name:
         description: |
-          Node pool name (max character length of x)
+          Node pool name. _(Length between 1-100, cannot contain control codes such as newline.)_
         type: string
       availability_zones:
         description: |
@@ -825,11 +825,11 @@ definitions:
             type: integer
             description: |
               Number of zones to use. If given, the zones are picked
-              automatically.
+              automatically. _(Maximum limit of 4 supported.)_
           zones:
             type: array
             description: |
-              Names of the availability zones to use.
+              Names of the availability zones to use. _(Must be same region as the cluster.)_
             items:
               type: string
       scaling:
@@ -840,10 +840,10 @@ definitions:
         type: object
         properties:
           min:
-            description: Minimum number of nodes in the pool
+            description: Minimum number of nodes in the pool, must be greater than 0, less than `max`.
             type: integer
           max:
-            description: Maximum number of nodes in the pool
+            description: Maximum number of nodes in the pool, must be greater than `min`.
             type: integer
       node_spec:
         description: Worker node specification
@@ -862,7 +862,7 @@ definitions:
           instance_type:
             type: string
             description: |
-              EC2 instance type to use for all nodes in the node pool
+              EC2 instance type to use for all nodes in the node pool. _(Validated against available instance types.)_
 
   # Specification of a node in a node pool after creation
   V5GetNodePoolResponseNodeSpec:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -811,7 +811,7 @@ definitions:
     properties:
       name:
         description: |
-          Node pool name
+          Node pool name (max character length of x)
         type: string
       availability_zones:
         description: |

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -835,15 +835,16 @@ definitions:
       scaling:
         description: |
           Attributes specific to cluster node scaling. To have full control of
-          the cluster size, min and max can be set to the same value. If only
-          `min` or only `max` is specified, `min` and `max` will be set equally.
+          the cluster size, min and max can be set to the same value, however `max`
+          must be greater or equal to `min`. If only `min` or only `max` is specified,
+          `min` and `max` will be set equally.
         type: object
         properties:
           min:
-            description: Minimum number of nodes in the pool, must be greater than 0, less than `max`.
+            description: Minimum number of nodes in the pool.
             type: integer
           max:
-            description: Maximum number of nodes in the pool, must be greater than `min`.
+            description: Maximum number of nodes in the pool.
             type: integer
       node_spec:
         description: Worker node specification

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -818,6 +818,8 @@ definitions:
           Specifies how the nodes of a pool are spread over availability zones.
           The object must contain either the `number` attribute or the `zones`
           attribute, but not both.
+          The maximum `number` of availbility zones is the same as that found
+          under `general.availability_zones.max` from the `/v4/info/` endpoint.
           When not given, availability zones assignment is handled automatically.
         type: object
         properties:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2552,6 +2552,16 @@ paths:
                   }
                 }
               }
+        "400":
+          description: Bad request
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"          
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The node pool could not be created. (Invalid name, length is greater than maximum length of 100.)"
+              }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         "404":

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2555,7 +2555,7 @@ paths:
         "400":
           description: Bad request
           schema:
-            $ref: "./definitions.yaml#/definitions/V4GenericResponse"          
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
           examples:
             application/json:
               {


### PR DESCRIPTION
Fields to be validated
---

| Field | Optional | Validation |
| ---- | --- | --- |
| NodePool Name | True | Length 0-100, block control characters |
| NodePool Scaling | True | `max >= min >= 1`. Default to 3 min max if both empty. Default to 3 min, if max provided > 3 |
| Availability Zones | - | Only one of `number` or `zones` |
| Availability Zones - `number` | True | `installations max >= number >= 1` (Check with Tuomas).  Default to 1 if no names nor numbers given |
| Availability Zones - `zones` | True | Regexp to validate name format `a-z, -, 0-9`. Validate against cluster region |
| Node Spec AWS Instance Type | True | Validate against info instance type list |

Invalid requests to return `400 Bad Request` with description of validation error