### PR TITLE
Adding node spec and status info

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -927,6 +927,16 @@ definitions:
         description: Worker node specification
         type: object
         $ref: '#/definitions/V5GetNodePoolResponseNodeSpec'
+      status:
+        description: Information on the current size and status of the node pool
+        type: object
+        properties:
+          nodes:
+            description: Desired number of nodes in the pool
+            type: integer
+          nodes_ready:
+            description: Number of nodes in state NodeReady
+            type: integer
 
 
   # Request to create a new cluster in V5

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2465,7 +2465,7 @@ paths:
                   "availability_zones": ["eu-west-1d"],
                   "scaling": {"min": 2, "max": 5},
                   "node_spec": {
-                    "aws": {"instance_type": "p3.8xlarge"}
+                    "aws": {"instance_type": "p3.8xlarge"},
                     "volume_sizes_gb": {"docker": 100, "kubelet": 100}
                   },
                   "status": {

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2464,14 +2464,28 @@ paths:
                   "name": "Batch number crunching",
                   "availability_zones": ["eu-west-1d"],
                   "scaling": {"min": 2, "max": 5},
-                  "node_spec": {"aws": {"instance_type": "p3.8xlarge"}}
+                  "node_spec": {
+                    "aws": {"instance_type": "p3.8xlarge"}
+                    "volume_sizes_gb": {"docker": 100, "kubelet": 100}
+                  },
+                  "status": {
+                    "nodes": 4,
+                    "nodes_ready": 3
+                  }
                 },
                 {
                   "id": "6fe",
                   "name": "Application servers",
                   "availability_zones": ["eu-west-1a", "eu-west-1b", "eu-west-1c"],
                   "scaling": {"min": 3, "max": 15},
-                  "node_spec": {"aws": {"instance_type": "p3.2xlarge"}}
+                  "node_spec": {
+                    "aws": {"instance_type": "p3.2xlarge"},
+                    "volume_sizes_gb": {"docker": 100, "kubelet": 100}
+                  },
+                  "status": {
+                    "nodes": 11,
+                    "nodes_ready": 11
+                  }
                 }
               ]
         "401":
@@ -2611,6 +2625,10 @@ paths:
                     "docker": 100,
                     "kubelet": 100
                   }
+                },
+                "status": {
+                  "nodes": 4,
+                  "nodes_ready": 3
                 }
               }
         "401":


### PR DESCRIPTION
Based on and to be merged into #130 (node-pools)

I found that so far we haven't integrated the following node pool info into the spec

- nodes and nodes ready

Also it would be practical to have all node pools details available when listing node pools for a cluster. So adding the following details to the response:

- nodes and nodes ready
- volume sizes