### PR TITLE
Add catalog-type labels

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -24,6 +24,14 @@ definitions:
             name:
               description: A URL friendly identifier for the catalog.
               type: string
+            labels:
+              description: The labels that are set on this app catalog
+              type: object
+              properties:
+                "application.giantswarm.io/catalog-type":
+                  type: string
+                "app-operator.giantswarm.io/version":
+                  type: string
         spec:
           type: object
           properties:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -111,12 +111,39 @@ paths:
         including a URL to fetch the full index of each catalog.
 
 
+        #### About the Labels
+
+        - `application.giantswarm.io/catalog-type`
+          Describes the type of catalog.
+
+          - `managed` - Apps in this catalog are managed by Giant Swarm.
+          - `incubator` - Apps in this catalog are a work in progress. They're
+                          made with your Giant Swarm cluster in mind though, so
+                          they should work. Feedback is appreciated on these apps.
+          - `test` - Apps in this catalog will soon graduate to incubator status,
+                     you most likely will not see any `test` catalogs on your
+                     installations.
+          - `community` - Apps in this catalog are provided by the kubernetes
+                          community. They will most likely not work without making
+                          some changes to the security settings of your cluster.
+
+          App Catalogs can also be labeled as `internal`, however these catalogs
+          contain apps that run on our control planes. These `internal` app catalogs
+          will be filtered out and never shown when calling this endpoint.
+
+          For more details on app catalogs visit: https://docs.giantswarm.io/basics/app-catalog/
+
+
         ### Example
         ```json
           [
             {
               "metadata": {
                 "name": "sample-catalog",
+                "labels": {
+                  "application.giantswarm.io/catalog-type": "test",
+                  "app-operator.giantswarm.io/version": "1.0.0",
+                },
               },
 
               "spec": {
@@ -146,14 +173,24 @@ paths:
             application/json:
               [
                 {
-                  "description": "Giant Swarm's Sample Catalog with a few apps to test things out.",
-                  "logoURL": "https://s.giantswarm.io/app-catalog/1/images/sample-catalog.png",
-                  "name": "sample-catalog",
-                  "storage": {
-                    "URL": "https://giantswarm.github.com/sample-catalog/",
-                    "type": "helm"
+                  "metadata": {
+                    "name": "sample-catalog",
+                    "labels": {
+                      "application.giantswarm.io/catalog-type": "test",
+                      "app-operator.giantswarm.io/version": "1.0.0",
+                    },
                   },
-                  "title": "Sample Catalog"
+
+                  "spec": {
+                    "description": "Giant Swarm's Sample Catalog with a few apps to test things out.",
+                    "logoURL": "https://s.giantswarm.io/app-catalog/1/images/sample-catalog.png",
+
+                    "storage": {
+                      "URL": "https://giantswarm.github.com/sample-catalog/",
+                      "type": "helm"
+                    },
+                    "title": "Sample Catalog"
+                  }
                 }
               ]
         "401":


### PR DESCRIPTION
This adds the labels on an `app catalog CR` to the `get catalogs` api endpoint output.