### PR TITLE
Simplify response for getNodePools

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -813,13 +813,6 @@ definitions:
         type: string
         description: The newly created API token
 
-
-  # List of node pools
-  V5GetNodePoolsResponse:
-    type: array
-    items:
-      $ref: '#/definitions/V5GetNodePoolResponse'
-
   # Add node pool
   V5AddNodePoolRequest:
     description: |

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2604,7 +2604,9 @@ paths:
         "200":
           description: Node pools list
           schema:
-            $ref: "./definitions.yaml#/definitions/V5GetNodePoolsResponse"
+            type: array
+            items:
+              $ref: "./definitions.yaml#/definitions/V5GetNodePoolResponse"
           examples:
             application/json:
               [


### PR DESCRIPTION
This changes the response type definition for the `getNodePools` operation so that there is no longer a named response type. Instead the response will be an array of named response types.