### PR TITLE
Add features section to info response

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -89,17 +89,17 @@ definitions:
               default:
                 description: Default number of availability zones for a cluster.
                 type: integer
-          features:
+      features:
+        type: object
+        description: Information on particular capabilities of the installation.
+        properties:
+          nodepools:
             type: object
-            description: Information on particular capabilities of the installation.
+            description: Support for grouping of worker nodes into node pools.
             properties:
-              nodepools:
-                type: object
-                description: Support for grouping of worker nodes into node pools.
-                properties:
-                  release_version_minimum:
-                    type: string
-                    description: The minimum release version number required to have support for node pools.
+              release_version_minimum:
+                type: string
+                description: The minimum release version number required to have support for node pools.
       stats:
         type: object
         description: Statistics about the installation

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -89,6 +89,17 @@ definitions:
               default:
                 description: Default number of availability zones for a cluster.
                 type: integer
+          features:
+            type: object
+            description: Information on particular capabilities of the installation.
+            properties:
+              nodepools:
+                type: object
+                description: Support for grouping of worker nodes into node pools.
+                properties:
+                  release_version_minimum:
+                    type: string
+                    description: The minimum release version number required to have support for node pools.
       stats:
         type: object
         description: Statistics about the installation

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -296,11 +296,11 @@ paths:
                   "availability_zones": {
                     "max": 3,
                     "default": 1
-                  },
-                  "features": {
-                    "nodepools": {
-                      "release_version_minimum": "10.0.0"
-                    }
+                  }
+                },
+                "features": {
+                  "nodepools": {
+                    "release_version_minimum": "10.0.0"
                   }
                 },
                 "stats": {

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -296,6 +296,11 @@ paths:
                   "availability_zones": {
                     "max": 3,
                     "default": 1
+                  },
+                  "features": {
+                    "nodepools": {
+                      "release_version_minimum": "10.0.0"
+                    }
                   }
                 },
                 "stats": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5465

This PR adds an attribute to the `GET /v4/info/` response that will allow clients to detect from which release version on support for node pools will be available.