### PR TITLE
Add secret CRUD endpoints to api-spec.

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -470,6 +470,16 @@ definitions:
     description: A part of the App CR that we create behind the scenes
     additionalProperties: true
 
+  V4GetClusterAppSecretResponse:
+    type: object
+    description: The response for showing a Secret for a given app
+    additionalProperties: true
+
+  V4CreateClusterAppSecretRequest:
+    type: object
+    description: The values to be used when creating a Secret for a given app
+    additionalProperties: true
+
   V4GetClusterStatusResponse:
     type: object
     description: Object about a cluster's current state

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -420,7 +420,7 @@ definitions:
             type: string
             description: The catalog that this app came from
           user_config:
-            $ref: './definitions.yaml#/definitions/V4AppSpecUserConfigConfigMap'
+            $ref: './definitions.yaml#/definitions/V4AppSpecUserConfig'
       status:
         type: object
         properties:
@@ -440,7 +440,7 @@ definitions:
                 type: string
                 description: "A string representing the status of the app. (Can be: empty, DEPLOYED or FAILED)"
 
-  V4AppSpecUserConfigConfigMap:
+  V4AppSpecUserConfig:
     type: object
     description: User definable configuration to be applied when the app is deployed
     properties:
@@ -453,6 +453,15 @@ definitions:
           namespace:
             type: string
             description: Namespace of the values config map on the control plane, e.g. 123ab
+      secret:
+        type: object
+        properties:
+          name:
+            type: string
+            description: Name of the Secret on the control plane, which will become available wherever the app is installed
+          namespace:
+            type: string
+            description: Namespace of the Secret on the control plane, e.g. 123ab
 
   V4GetClusterAppsResponse:
     type: array

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -61,6 +61,8 @@ tags:
     description: "An app is a helm chart that you can easily install on your tenant clusters. Use these endpoints to: find out what catalogs your installation supports, and list and install apps on on your tenant clusters."
   - name: app configs
     description: "Creating an app config lets you supply your apps with custom configuration values."
+  - name: app secrets
+    description: "Creating a secret lets you supply your apps with custom secret values."
   - name: organizations
     description: Organizations are groups of users who own resources like clusters.
   - name: users
@@ -1752,6 +1754,243 @@ paths:
               {
                 "code": "INVALID_INPUT",
                 "message": "App config could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v4/clusters/{cluster_id}/apps/{app_name}/secret/:
+    get:
+      operationId: getClusterAppSecret
+      tags:
+        - app secrets
+      summary: Get Secret
+      description: |
+        This operation allows you to fetch the Secret associated
+        with an app.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppSecretResponse"
+          examples:
+            appication/json:
+              {
+                "secret": "value"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Secret not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Unable to show Secret. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
+              }
+    put:
+      operationId: createClusterAppSecret
+      tags:
+        - app secrets
+      summary: Create Secret
+      description: |
+        This operation allows you to create a Secret for a specific app. The app does
+        not have to exist before hand.
+
+        If the app does exist, this endpoint will ensure that the App CR gets it's
+        `spec.user_config.secret` field set correctly.
+
+        However, if the app exists and the `spec.user_config.secret` is already set to something,
+        then this request will fail. You will in that case most likely want to
+        update the Secret using the `PATCH /v4/clusters/{cluster_id}/apps/{app_name}/secret/`
+        endpoint.
+
+
+        ### Example POST request
+        ```json
+          {
+            "secret": "value"
+          }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateClusterAppSecretRequest"
+          x-examples:
+            appication/json:
+              {
+                "secret": "value"
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            appication/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "Secret for 'my-awesome-app' on 'abc12' has been created."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "Secret could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: Secret already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "A Secret for 'my-awesome-app' on 'abc12' already exists."
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    delete:
+      operationId: deleteClusterAppSecret
+      tags:
+        - app secrets
+      summary: Delete a Secret
+      description: |
+        This operation allows a user to delete an app's Secret if it has been named according to the convention of {app-name}-user-secret and
+        stored in the cluster ID namespace.
+
+        Calling this endpoint will delete the Secret, and also remove the reference to the Secret in the (spec.user_config.secret field) from the app.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: './parameters.yaml#/parameters/ClusterIdPathParameter'
+        - $ref: './parameters.yaml#/parameters/AppNamePathParameter'
+      responses:
+        "200":
+          description: Secret deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "Secret for 'my-app' on 'abc12' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Secret not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The Secret of app 'my-app' could not be deleted. ('my-app' not found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    patch:
+      operationId: modifyClusterAppSecret
+      tags:
+        - app secrets
+      summary: Modify Secret
+      description: |
+        This operation allows you to modify the Secret for a specific app.
+        It's only possible to modify Secrets that have been named according to the convention of
+        {app-name}-secret and stored in the cluster ID namespace.
+
+        The full values key of the Secret will be replaced by the JSON body
+        of your request.
+
+        ### Example PATCH request
+        ```json
+          {
+            "secret": "new-value"
+          }
+        ```
+
+        If the Secret contained content like:
+
+        ```json
+          {
+            "secret": "old-value",
+            "secret2": "another-old-value"
+          }
+        ```
+
+        Then the "secret2" will be removed, and "secret" will be set to "new-value"
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateClusterAppSecretRequest"
+          x-examples:
+            application/json:
+              {
+                "secret": "new-value"
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            appication/json:
+              {
+                "code": "RESOURCE_UPDATED",
+                "message": "Secret for 'my-awesome-app' on 'abc12' has been updated."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "Secret could not be created. (invalid input)"
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1882,7 +1882,7 @@ paths:
         - app secrets
       summary: Delete a Secret
       description: |
-        This operation allows a user to delete an app's Secret if it has been named according to the convention of {app-name}-user-secret and
+        This operation allows a user to delete an app's Secret if it has been named according to the convention of {app-name}-user-secrets and
         stored in the cluster ID namespace.
 
         Calling this endpoint will delete the Secret, and also remove the reference to the Secret in the (spec.user_config.secret field) from the app.
@@ -1928,7 +1928,7 @@ paths:
       description: |
         This operation allows you to modify the Secret for a specific app.
         It's only possible to modify Secrets that have been named according to the convention of
-        {app-name}-secret and stored in the cluster ID namespace.
+        {app-name}-user-secrets and stored in the cluster ID namespace.
 
         The full values key of the Secret will be replaced by the JSON body
         of your request.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1772,7 +1772,6 @@ paths:
         This operation allows you to fetch the Secret associated
         with an app.
       parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
@@ -1825,7 +1824,6 @@ paths:
           }
         ```
       parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
@@ -1889,7 +1887,6 @@ paths:
 
         Calling this endpoint will delete the Secret, and also remove the reference to the Secret in the (spec.user_config.secret field) from the app.
       parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
@@ -1955,7 +1952,6 @@ paths:
         Then the "secret2" will be removed, and "secret" will be set to "new-value"
 
       parameters:
-        - $ref: './parameters.yaml#/parameters/RequiredGiantSwarmAuthorizationHeader'
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'


### PR DESCRIPTION
This adds CRUD endpoints at `/v4/clusters/{cluster_id}/apps/{app_name}/secret/`

@rossf7 and others, are there any decisions made yet regarding the conventional name for the user config secret?

Like how the configmap should be called `{app-name}-user-values`.
What should / will the secret be called?