### PR TITLE
Remove nodepools from addClusterV5 request body

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1000,13 +1000,6 @@ definitions:
             description: |
               Name of the availability zone to use for the master node. If not
               given, the master node will be placed automatically.
-      nodepools:
-        description: |
-          Specification of node pools to be created immediately with the
-          cluster.
-        type: array
-        items:
-          $ref: '#/definitions/V5AddNodePoolRequest'
 
   V5ClusterDetailsResponse:
     type: object

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2385,21 +2385,7 @@ paths:
                 "name": "Production cluster using k8s 1.14",
                 "master": {
                   "availability_zone": "europe-central-1c"
-                },
-                "nodepools": [
-                  {
-                    "name": "General purpose",
-                    "availability_zones": {
-                      "number": 2
-                    },
-                    "scaling": {"min": 3, "max": 30},
-                    "node_spec": {
-                      "aws": {
-                        "instance_type": "m4.2xlarge"
-                      }
-                    }
-                  }
-                ]
+                }
               }
       responses:
         "201":
@@ -2416,18 +2402,7 @@ paths:
                 "master": {
                   "availability_zone": "europe-central-1c"
                 },
-                "nodepools": [
-                  {
-                    "name": "General purpose",
-                    "availability_zones": ["europe-central-1a", "europe-central-1c"],
-                    "scaling": {"min": 3, "max": 30},
-                    "node_spec": {
-                      "aws": {
-                        "instance_type": "m4.2xlarge"
-                      }
-                    }
-                  }
-                ]
+                "nodepools": []
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5465

As detailed in https://github.com/giantswarm/giantswarm/issues/5465#issuecomment-528360513 we decided to simplify v5 cluster creation, removing the possibility to define node pools in the same request.