### PR TITLE
Add minimum cpu and memory sizes to info endpoint.

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -155,6 +155,28 @@ definitions:
               default:
                 description: The instance type used in new cluster, if not specified
                 type: string
+          cpu:
+            description: CPU related limits. Only available on KVM installations.
+            type: object
+            properties:
+              cores:
+                description: Validation values for the CPU core count of a worker.
+                type: object
+                properties:
+                  min:
+                    description: The minimum amount of CPU cores a worker must have.
+                    type: integer
+          memory:
+            description: Memory related limits. Only avaialble on KVM installations.
+            type: object
+            properties:
+              size_gb:
+                description: Validation values for the amount of memory of a worker.
+                type: object
+                properties:
+                  min:
+                    description: The minimum amount of memory a worker must have.
+                    type: integer
 
   # Request to create a new cluster in V4
   V4AddClusterRequest:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -272,6 +272,16 @@ paths:
               "max": 8,
               "default": 3
             },
+            "cpu": {
+              "cores": {
+                "min": 2
+              }
+            },
+            "memory": {
+              "size_gb": {
+                "min": 3
+              }
+            }
           }
         }
         ```


### PR DESCRIPTION
I've introduced a way to validate minimum CPU Core and Memory values on KVM installations. 

It would be nice to expose this information so that our clients can also act on it and set sensible starting values.

see: https://github.com/giantswarm/api/pull/855
see: https://github.com/giantswarm/installations/pull/887