### PR TITLE
Add app labels

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -414,6 +414,10 @@ definitions:
           name:
             type: string
             description: The identifier you set when creating this app
+          labels:
+            type: object
+            description: The labels that are set on this App
+            additionalProperties: true
       spec:
         type: object
         properties:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1186,6 +1186,7 @@ paths:
             {
               "metadata": {
                 "name": "my-awesome-prometheus",
+                "labels": {}
               },
 
               "spec": {
@@ -1228,6 +1229,7 @@ paths:
                 {
                   "metadata": {
                     "name": "my-awesome-prometheus",
+                    "labels": {},
                   },
 
                   "spec": {


### PR DESCRIPTION
This adds `labels` to the Apps response.

The idea would be to include labels like:

```
    app: chart-operator
    app-operator.giantswarm.io/version: 1.0.0
    giantswarm.io/cluster: pbd2x
    giantswarm.io/managed-by: cluster-operator
    giantswarm.io/organization: giantswarm
    giantswarm.io/service-type: managed
```

In the API response so that UI's can figure out whether or not the App was preinstalled 

Is: `managed-by: cluster-operator` a guaranteed 'preinstalled' app?

Do we need a new label to make this more explicit?

ping @puja108 @rossf7 

I got those labels from a cluster on ginger:  `kubectl get apps -n pbd2x chart-operator -o yaml`