### PR TITLE
Add availability zone names to info endpoint response

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -91,7 +91,7 @@ definitions:
                 type: integer
               zones:
                 type: array
-                description: The distinct availability zones available in the installation's region.
+                description: The availability zones available for in the installation's region for use with tenant clusters.
                 items:
                   type: string
       features:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -91,7 +91,7 @@ definitions:
                 type: integer
               zones:
                 type: array
-                description: The availability zones available for in the installation's region for use with tenant clusters.
+                description: The availability zones available in the installation's region for use with tenant clusters.
                 items:
                   type: string
       features:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -89,6 +89,11 @@ definitions:
               default:
                 description: Default number of availability zones for a cluster.
                 type: integer
+              zones:
+                type: array
+                description: The distinct availability zones available in the installation's region.
+                items:
+                  type: string
       features:
         type: object
         description: Information on particular capabilities of the installation.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -225,6 +225,9 @@ paths:
             "availability_zones": {
               "max": 3,
               "default": 1,
+              "zones": [
+                "eu-central-1a", "eu-central-1b", "eu-central-1c"
+              ]
             }
           },
           "stats": {
@@ -295,7 +298,10 @@ paths:
                   "datacenter": "eu-central-1",
                   "availability_zones": {
                     "max": 3,
-                    "default": 1
+                    "default": 1,
+                    "zones": [
+                      "eu-central-1a", "eu-central-1b", "eu-central-1c"
+                    ]
                   }
                 },
                 "features": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7105

This PR adds the capability to let the info endpoint (`GET /v4/info/`) inform about the distinct availability zone names usable in a region.