### PR TITLE
Add default case to addKeyPair operation

### DIFF
--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1131,6 +1131,10 @@ paths:
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
   /v4/clusters/{cluster_id}/status/:
     get:


### PR DESCRIPTION
This adds a missing default case to the  `addKeyPair` operation and should simplify error handling in clients.