### PR TITLE
Remove yamllint installation step from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,6 @@ jobs:
   build:
     machine: true
     steps:
-      - run:
-          name: Install yamllint
-          command: |
-            sudo apt-get update && sudo apt-get install -y python-pip
-            sudo pip install yamllint
-
       - checkout
 
       - run:


### PR DESCRIPTION
Cleaning up the CI config, avoiding waste of time and resources