### PR TITLE
Add 'make mock' command to enable running a prism mock server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,6 @@ test: lint
 run-server:
 	docker build -t api-spec-dev -f Dockerfile .
 	docker run --rm -p 8080:8000 api-spec-dev
+
+mock:
+	docker run --rm -it -p 4010:4010 -v $(shell pwd)/spec:/spec stoplight/prism:3 mock -h 0.0.0.0 "/spec/spec.yaml"

--- a/Makefile
+++ b/Makefile
@@ -57,4 +57,7 @@ run-server:
 	docker run --rm -p 8080:8000 api-spec-dev
 
 mock:
-	docker run --rm -it -p 4010:4010 -v $(shell pwd)/spec:/spec stoplight/prism:3 mock -h 0.0.0.0 "/spec/spec.yaml"
+	docker run --rm -it -p 4010:4010 -v $(shell pwd)/spec:/spec stoplight/prism:3 mock -h 0.0.0.0 --cors "/spec/spec.yaml"
+
+mock-dynamic:
+	docker run --rm -it -p 4010:4010 -v $(shell pwd)/spec:/spec stoplight/prism:3 mock -h 0.0.0.0 --cors --dynamic "/spec/spec.yaml"

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ make mock
 ```
 
 Then access `http://localhost:4010` as your endpoint. E. g. `gsctl -e http://localhost:4010 list clusters`.
+
+Alternatively, you can run `make mock-dynamic` to let the mock server respond with dynamically generated [fake](https://github.com/json-schema-faker/json-schema-faker) data.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,10 @@ make run-server
 
 Then open [`http://localhost:8080/`](http://localhost:8080/) to access your specs displayed via ReDoc.
 
+### Running a mock server
+
+```nohighlight
+make mock
+```
+
+Then access `http://localhost:4010` as your endpoint. E. g. `gsctl -e http://localhost:4010 list clusters`.


### PR DESCRIPTION
To simplify API testing we are exploring the use of https://github.com/stoplightio/prism which creates a mock service based on the spec.

### Usage

Run `make mock`.

### Preview

gsctl

![image](https://user-images.githubusercontent.com/273727/68302700-d36c1800-00a2-11ea-8339-31f5a27a847b.png)

Server log

![image](https://user-images.githubusercontent.com/273727/68302789-f4346d80-00a2-11ea-80a3-93631631d87d.png)
