### PR TITLE
Set more schema details

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -347,6 +347,9 @@ definitions:
                   description: |
                     The protocol this port mapping is made for.
                   type: string
+                  oneOf:
+                    - http
+                    - https
 
   # Definition of a v4 cluster node
   V4NodeDefinition:
@@ -477,7 +480,11 @@ definitions:
                 format: dateTime
               status:
                 type: string
-                description: "A string representing the status of the app. (Can be: empty, DEPLOYED or FAILED)"
+                description: A string representing the status of the app.
+                oneOf:
+                  - ""
+                  - DEPLOYED
+                  - FAILED
 
   V4AppSpecUserConfig:
     type: object
@@ -779,6 +786,9 @@ definitions:
     properties:
       provider:
         type: string
+        oneOf:
+          - aws
+          - azure
       aws:
         type: object
         description: Credentials specific to an AWS account
@@ -836,6 +846,9 @@ definitions:
       provider:
         type: string
         description: Either 'aws' or 'azure'
+        oneOf:
+          - aws
+          - azure
       aws:
         type: object
         description: Credentials specific to an AWS account

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -352,9 +352,6 @@ definitions:
                   description: |
                     The protocol this port mapping is made for.
                   type: string
-                  oneOf:
-                    - http
-                    - https
 
   # Definition of a v4 cluster node
   V4NodeDefinition:
@@ -491,10 +488,6 @@ definitions:
               status:
                 type: string
                 description: A string representing the status of the app.
-                oneOf:
-                  - ""
-                  - DEPLOYED
-                  - FAILED
 
   V4AppSpecUserConfig:
     type: object
@@ -799,9 +792,6 @@ definitions:
     properties:
       provider:
         type: string
-        oneOf:
-          - aws
-          - azure
       aws:
         type: object
         description: Credentials specific to an AWS account
@@ -859,9 +849,6 @@ definitions:
       provider:
         type: string
         description: Either 'aws' or 'azure'
-        oneOf:
-          - aws
-          - azure
       aws:
         type: object
         description: Credentials specific to an AWS account
@@ -922,7 +909,6 @@ definitions:
       auth_token:
         type: string
         description: The newly created API token
-
 
   # List of node pools
   V5GetNodePoolsResponse:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -349,12 +349,14 @@ definitions:
           size_gb:
             type: number
             description: RAM size in GB. Can be an integer or float.
+            format: float
       storage:
         type: object
         properties:
           size_gb:
             type: number
             description: Node storage size in GB. Can be an integer or float.
+            format: float
       cpu:
         type: object
         properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -96,6 +96,8 @@ definitions:
               zones:
                 type: array
                 description: The availability zones available in the installation's region for use with tenant clusters.
+                minItems: 1
+                maxItems: 10
                 items:
                   type: string
       features:
@@ -313,6 +315,8 @@ definitions:
       availability_zones:
         description: List of availability zones a cluster is spread across.
         type: array
+        minItems: 1
+        maxItems: 4
         items:
           description: Name of the availability zone
           type: string
@@ -930,6 +934,7 @@ definitions:
             type: array
             description: |
               Names of the availability zones to use. _(Must be same region as the cluster.)_
+            minItems: 1
             items:
               type: string
       scaling:
@@ -1007,6 +1012,8 @@ definitions:
         description: |
           Names of the availability zones used by the nodes of this pool.
         type: array
+        minItems: 1
+        maxItems: 4
         items:
           description: Name of the availability zone
           type: string

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -132,10 +132,10 @@ definitions:
             properties:
               max:
                 description: Maximum number of worker a cluster can have. Might be null when unknown.
-                type: number
+                type: integer
               default:
                 description: Default number of workers in a new cluster will have, if not specifiec otherwise
-                type: number
+                type: integer
           instance_type:
             description: Instance types to be used for worker nodes. Only available for AWS clusters.
             type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -695,6 +695,7 @@ definitions:
       password:
         type: string
         description: A Base64 encoded password
+        format: byte
       expiry:
         type: string
         description: The date and time when this account will expire
@@ -719,9 +720,11 @@ definitions:
       current_password_base64:
         type: string
         description: Current password encoded in Base64. Not required for admins
+        format: byte
       new_password_base64:
         type: string
         description: New password encoded in Base64
+        format: byte
 
   V4AddCredentialsRequest:
     type: object
@@ -839,6 +842,7 @@ definitions:
       password_base64:
         type: string
         description: Your password as a base64 encoded string
+        format: byte
 
   # A response to a successful auth token request
   V4CreateAuthTokenResponse:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -690,7 +690,7 @@ definitions:
   # A release array item, as return by getReleases
   V4ReleaseListItem:
     type: object
-    required: ["version", "timestamp", "changelog", "components"]
+    required: ["active", "version", "timestamp", "changelog", "components"]
     properties:
       version:
         type: string

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -86,9 +86,13 @@ definitions:
               max:
                 description: Number of availability zones in the region of this installation.
                 type: integer
+                minimum: 0
+                maximum: 10
               default:
                 description: Default number of availability zones for a cluster.
                 type: integer
+                minimum: 1
+                maximum: 3
               zones:
                 type: array
                 description: The availability zones available in the installation's region for use with tenant clusters.
@@ -116,12 +120,15 @@ definitions:
               median:
                 type: integer
                 description: Median of the value distribution
+                minimum: 0
               p25:
                 type: integer
                 description: 25th percentile of the value distribution
+                minimum: 0
               p75:
                 type: integer
                 description: 75th percentile of the value distribution
+                minimum: 0
       workers:
         description: Information related to worker nodes
         type: object
@@ -133,9 +140,11 @@ definitions:
               max:
                 description: Maximum number of worker a cluster can have. Might be null when unknown.
                 type: integer
+                minimum: 0
               default:
                 description: Default number of workers in a new cluster will have, if not specifiec otherwise
                 type: integer
+                minimum: 0
           instance_type:
             description: Instance types to be used for worker nodes. Only available for AWS clusters.
             type: object
@@ -184,6 +193,8 @@ definitions:
           Number of availability zones a cluster should be spread across. The
           default is provided via the [info](#operation/getInfo) endpoint.
         type: integer
+        minimum: 1
+        maximum: 4
       scaling:
         type: object
         description: |
@@ -196,10 +207,14 @@ definitions:
             type: integer
             description: |
               Minimum number of cluster nodes
+            minimum: 1
+            maximum: 999
           max:
             type: integer
             description: |
               Maximum number of cluster nodes
+            minimum: 1
+            maximum: 999
       workers:
         type: array
         description: |
@@ -232,10 +247,14 @@ definitions:
             type: integer
             description: |
               Minimum number of cluster nodes
+            minimum: 1
+            maximum: 999
           max:
             type: integer
             description: |
               Maximum number of cluster nodes
+            minimum: 1
+            maximum: 999
       workers:
         type: array
         description: Worker node array (deprecated)
@@ -283,10 +302,14 @@ definitions:
             type: integer
             description: |
               Minimum number of cluster nodes as configured
+            minimum: 1
+            maximum: 999
           max:
             type: integer
             description: |
               Maximum number of cluster nodes as configured
+            minimum: 1
+            maximum: 999
       availability_zones:
         description: List of availability zones a cluster is spread across.
         type: array
@@ -314,6 +337,8 @@ definitions:
                   description: |
                     The port on the control plane that will forward traffic to the tenant cluster
                   type: integer
+                  minimum: 1
+                  maximum: 65535
                 protocol:
                   description: |
                     The protocol this port mapping is made for.
@@ -363,6 +388,7 @@ definitions:
           cores:
             type: integer
             description: Number of CPU cores
+            minimum: 2
       labels:
         type: object
         additionalProperties: true
@@ -519,6 +545,7 @@ definitions:
         ttl_hours:
           type: integer
           description: Expiration time (from creation) in hours
+          minimum: 1
         create_date:
           type: string
           description: Date/time of creation
@@ -543,6 +570,7 @@ definitions:
         type: integer
         format: int32
         description: Expiration time (from creation) in hours
+        minimum: 1
       cn_prefix:
         type: string
         description: The common name prefix of the certificate subject. This only allows characters that are usable in domain names (`a-z`, `0-9`, and `.-`, where `.-` must not occur at either the start or the end).
@@ -564,6 +592,7 @@ definitions:
       ttl_hours:
         type: integer
         description: Expiration time (from creation) in hours
+        minimum: 1
       create_date:
         type: string
         description: Date/time of creation
@@ -896,6 +925,7 @@ definitions:
             description: |
               Number of zones to use. If given, the zones are picked
               automatically. _(Maximum limit of 4 supported.)_
+            maximum: 4
           zones:
             type: array
             description: |
@@ -913,9 +943,11 @@ definitions:
           min:
             description: Minimum number of nodes in the pool.
             type: integer
+            minimum: 0
           max:
             description: Maximum number of nodes in the pool.
             type: integer
+            minimum: 0
       node_spec:
         description: Worker node specification
         type: object
@@ -988,9 +1020,11 @@ definitions:
           min:
             description: Minimum number of nodes in the pool
             type: integer
+            minimum: 1
           max:
             description: Maximum number of nodes in the pool
             type: integer
+            minimum: 1
       subnet:
         description: IP address block used by the node pool
         type: string
@@ -1005,9 +1039,11 @@ definitions:
           nodes:
             description: Desired number of nodes in the pool
             type: integer
+            minimum: 0
           nodes_ready:
             description: Number of nodes in state NodeReady
             type: integer
+            minimum: 0
 
 
   # Request to create a new cluster in V5
@@ -1134,6 +1170,8 @@ definitions:
           min:
             description: Minimum number of nodes in the pool
             type: integer
+            minimum: 1
           max:
             description: Maximum number of nodes in the pool
             type: integer
+            minimum: 1

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -271,6 +271,7 @@ definitions:
       id:
         type: string
         description: Unique cluster identifier
+        pattern: "[a-z0-9]{5}"
       api_endpoint:
         type: string
         description: URI of the Kubernetes API endpoint
@@ -670,6 +671,7 @@ definitions:
       id:
         type: string
         description: Unique cluster identifier
+        pattern: "[a-z0-9]{5}"
       create_date:
         type: string
         description: Date/time of cluster creation
@@ -1021,6 +1023,7 @@ definitions:
       id:
         description: Node pool identifier. Unique within a tenant cluster.
         type: string
+        pattern: "[a-z0-9]{5}"
       name:
         description: Node pool name
         type: string
@@ -1051,6 +1054,7 @@ definitions:
       subnet:
         description: IP address block used by the node pool
         type: string
+        pattern: "[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}/[0-9]+"
       node_spec:
         description: Worker node specification
         type: object
@@ -1107,6 +1111,7 @@ definitions:
       id:
         type: string
         description: Unique cluster identifier
+        pattern: "[a-z0-9]{5}"
       api_endpoint:
         type: string
         description: URI of the Kubernetes API endpoint

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -927,6 +927,9 @@ definitions:
         description: |
           Node pool name. _(Length between 1-100, cannot contain control codes such as newline.)_
         type: string
+        default: Unnamed node pool
+        minLength: 1
+        maxLength: 100
       availability_zones:
         description: |
           Specifies how the nodes of a pool are spread over availability zones.
@@ -1079,6 +1082,7 @@ definitions:
       name:
         type: string
         description: Cluster name
+        default: Unnamed cluster
       release_version:
         type: string
         description: |

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -111,6 +111,7 @@ definitions:
               release_version_minimum:
                 type: string
                 description: The minimum release version number required to have support for node pools.
+                format: semver
       stats:
         type: object
         description: Statistics about the installation
@@ -190,6 +191,7 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           to use in the new cluster
+        format: semver
       availability_zones:
         description: |
           Number of availability zones a cluster should be spread across. The
@@ -239,6 +241,7 @@ definitions:
       release_version:
         type: string
         description: Release version to use after an upgrade
+        format: semver
       scaling:
         type: object
         description: |
@@ -295,6 +298,7 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           currently running this cluster.
+        format: semver
       scaling:
         type: object
         description: |
@@ -422,6 +426,7 @@ definitions:
           version:
             type: string
             description: Version of the chart that should be used to install this app
+            format: semver
           catalog:
             type: string
             description: The catalog where the chart for this app can be found
@@ -436,6 +441,7 @@ definitions:
           version:
             type: string
             description: Version of the chart that should be used to install this app
+            format: semver
 
   V4App:
     type: object
@@ -458,6 +464,7 @@ definitions:
           version:
             type: string
             description: Version of the chart that was used to install this app
+            format: semver
           catalog:
             type: string
             description: The catalog that this app came from
@@ -469,9 +476,11 @@ definitions:
           app_version:
             type: string
             description: Version of the installed app
+            format: semver
           version:
             type: string
             description: Version of the chart that was used to install this app
+            format: semver
           release:
             type: object
             properties:
@@ -685,6 +694,7 @@ definitions:
       release_version:
         type: string
         description: The semantic version number of this cluster
+        format: semver
       path:
         type: string
         description: API path of the cluster resource
@@ -697,6 +707,7 @@ definitions:
       version:
         type: string
         description: The semantic version number
+        format: semver
       timestamp:
         type: string
         description: Date and time of the release creation
@@ -1093,6 +1104,7 @@ definitions:
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           to use in the new cluster. If not given, the latest release will be
           used.
+        format: semver
       master:
         type: object
         description: |
@@ -1136,6 +1148,7 @@ definitions:
         description: |
           The [release](https://docs.giantswarm.io/api/#tag/releases) version
           used by the cluster
+        format: semver
       master:
         type: object
         description: |
@@ -1170,6 +1183,7 @@ definitions:
             version:
               type: string
               description: Semantic version number
+              format: semver
 
   V5ModifyClusterRequest:
     type: object
@@ -1181,6 +1195,7 @@ definitions:
       release_version:
         type: string
         description: Release version to upgrade to
+        format: semver
 
   V5ModifyNodePoolRequest:
     type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -687,7 +687,7 @@ definitions:
         type: string
         description: API path of the cluster resource
 
-  # A cluster array item, as return by getClusters
+  # A release array item, as return by getReleases
   V4ReleaseListItem:
     type: object
     required: ["version", "timestamp", "changelog", "components"]

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -256,6 +256,7 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+        format: dateTime
       owner:
         type: string
         description: Name of the organization owning the cluster
@@ -441,6 +442,7 @@ definitions:
               last_deployed:
                 type: string
                 description: Date and time that the app was last last deployed
+                format: dateTime
               status:
                 type: string
                 description: "A string representing the status of the app. (Can be: empty, DEPLOYED or FAILED)"
@@ -518,6 +520,7 @@ definitions:
         create_date:
           type: string
           description: Date/time of creation
+          format: dateTime
         common_name:
           type: string
           description: The common name of the certificate subject.
@@ -562,6 +565,7 @@ definitions:
       create_date:
         type: string
         description: Date/time of creation
+        format: dateTime
       certificate_authority_data:
         type: string
         description: PEM-encoded CA certificate of the cluster
@@ -611,9 +615,11 @@ definitions:
       created:
         type: string
         description: The date and time that this account was created
+        format: dateTime
       expiry:
         type: string
         description: The date and time when this account will expire
+        format: dateTime
 
   # A cluster array item, as return by getClusters
   V4ClusterListItem:
@@ -625,6 +631,7 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+        format: dateTime
       name:
         type: string
         description: Cluster name
@@ -649,6 +656,7 @@ definitions:
       timestamp:
         type: string
         description: Date and time of the release creation
+        format: dateTime
       active:
         type: boolean
         description: |
@@ -699,6 +707,7 @@ definitions:
       expiry:
         type: string
         description: The date and time when this account will expire
+        format: dateTime
 
   V4ModifyUserRequest:
     type: object
@@ -710,6 +719,7 @@ definitions:
       expiry:
         type: string
         description: New expiry date. (Only editable by admins)
+        format: dateTime
 
   V4ModifyUserPasswordRequest:
     type: object
@@ -1041,6 +1051,7 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+        format: dateTime
       owner:
         type: string
         description: |
@@ -1076,6 +1087,7 @@ definitions:
             last_transition_time:
               type: string
               description: Date and time when the cluster transitioned into this condition
+              format: dateTime
             condition:
               type: string
               description: A string describing the condition, e. g. 'Created'
@@ -1087,6 +1099,7 @@ definitions:
             last_transition_time:
               type: string
               description: Date and time when the cluster got created with or upgraded to this version
+              format: dateTime
             version:
               type: string
               description: Semantic version number

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -964,6 +964,7 @@ definitions:
             description: |
               Names of the availability zones to use. _(Must be same region as the cluster.)_
             minItems: 1
+            maxItems: 4
             items:
               type: string
       scaling:


### PR DESCRIPTION
This experimental PR adds some schema specification where details were undefined so far, with the goal to improve automated mocking.

### List of changes

- In `V4ReleaseListItem` set field `active` as required
- in `V4InfoResponse` change type of `workers.count_per_cluster.max` and `workers.count_per_cluster.default` from `number` to `integer`. `number` is not wrong, but `integer` is more precise.
- add `format: byte` to string fields containing base64 data
- add `format: dateTime` to all string field which contain date/time values
- add `format: float` to fields of type `number`
- set `format: semver` to fields holding semantic version numbers
- set `minimum` and `maximum` where possible on integer fields
- set `minItems` and `maxItems` where possible on array fields
- set `minLength` and `maxLength` to string fields where it's actually known 
- set `pattern` to some string fields that allow it
