### PR TITLE
Add delete_date attribute

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -256,6 +256,10 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+      delete_date:
+        type: string
+        format: date
+        description: Date/time when cluster has been deleted
       owner:
         type: string
         description: Name of the organization owning the cluster
@@ -625,6 +629,10 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+      delete_date:
+        type: string
+        format: date
+        description: Date/time when cluster has been deleted
       name:
         type: string
         description: Cluster name
@@ -1037,6 +1045,10 @@ definitions:
       create_date:
         type: string
         description: Date/time of cluster creation
+      delete_date:
+        type: string
+        format: date
+        description: Date/time when cluster has been deleted
       owner:
         type: string
         description: |


### PR DESCRIPTION
API spec draft for https://github.com/giantswarm/giantswarm/issues/7516

The idea is to have deleted clusters appear

- in the `GET /v4/clusters/` response
- in the `GET /v4/clusters/{cluster_id}/` response
- in the `GET /v5/clusters/{cluster_id}/` response

as long as they are not fully deleted. The `delete_date` value should represent the date when deletion of the cluster has been requested.