### PR TITLE
Add cluster creator attribute

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -259,6 +259,9 @@ definitions:
       owner:
         type: string
         description: Name of the organization owning the cluster
+      creator:
+        type: string
+        description: Username of the user who created the cluster
       name:
         type: string
         description: Cluster name
@@ -1041,6 +1044,9 @@ definitions:
         type: string
         description: |
           Name of the organization owning the cluster
+      creator:
+        type: string
+        description: Username of the user who created the cluster
       name:
         type: string
         description: Cluster name

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -834,6 +834,7 @@ paths:
                 "api_endpoint": "https://api.wqtlq.example.com",
                 "name": "Just a Standard Cluster",
                 "release_version": "2.5.16",
+                "creator":  "admin@example.com",
                 "owner": "acme",
                 "credential_id": "a1b2c",
                 "availability_zones": ["fire-zone-1"],
@@ -2670,6 +2671,7 @@ paths:
                 "api_endpoint": "https://api.k8s.7g4di.example.com",
                 "name": "All purpose cluster",
                 "release_version": "11.0.0",
+                "creator":  "admin@example.com",
                 "owner": "acme",
                 "credential_id": "a1b2c",
                 "master": {

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -834,7 +834,7 @@ paths:
                 "api_endpoint": "https://api.wqtlq.example.com",
                 "name": "Just a Standard Cluster",
                 "release_version": "2.5.16",
-                "creator":  "admin@example.com",
+                "creator": "admin@example.com",
                 "owner": "acme",
                 "credential_id": "a1b2c",
                 "availability_zones": ["fire-zone-1"],
@@ -2671,7 +2671,7 @@ paths:
                 "api_endpoint": "https://api.k8s.7g4di.example.com",
                 "name": "All purpose cluster",
                 "release_version": "11.0.0",
-                "creator":  "admin@example.com",
+                "creator": "admin@example.com",
                 "owner": "acme",
                 "credential_id": "a1b2c",
                 "master": {


### PR DESCRIPTION
API spec draft for https://github.com/giantswarm/giantswarm/issues/7672

This adds the `creator` attribute to the v4 and v5 cluster details response, to expose who has created a cluster.