### PR TITLE
Add instance type/VM size spec to info endpoint response

### DIFF
--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -243,9 +243,17 @@ paths:
             },
             "instance_type": {
               "options": [
-                "m3.medium", "m3.large", "m3.xlarge"
+                "m5.xlarge", "m5.2xlarge", "m5.4xlarge"
               ],
-              "default": "m3.large"
+              "default": "m3.large",
+              "specification": [
+                {
+                  "name": "m5.xlarge",
+                  "description": "M5 series with medium resources",
+                  "cpu_cores": 4,
+                  "memory_size_gb": 16
+                }
+              ]
             }
           }
         }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/6697

This spec change should allow the info endpoint to provide all details about AWS instance types or Azure machine sizes required by our UIs.

### Preview

```
          "workers": {
            "count_per_cluster": {
              "max": null,
              "default": 3
            },
            "instance_type": {
              "options": [
                "m5.xlarge", "m5.2xlarge", "m5.4xlarge"
              ],
              "default": "m3.large",
              "specification": [
                {
                  "name": "m5.xlarge",
                  "description": "M5 series with medium resources",
                  "cpu_cores": 4,
                  "memory_size_gb": 16
                }
              ]
            }
          }
```

### TODO

- Make the spec provider-agnostic. `instance_type` is AWS terminology.
- [ ] Update definitions
- [ ] Check attribute naming for consistency