### PR TITLE
Support Azure Multi-AZ

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -183,7 +183,7 @@ definitions:
         description: |
           Number of availability zones a cluster should be spread across. The
           default is provided via the [info](#operation/getInfo) endpoint.
-        type: integer
+        type: string
       scaling:
         type: object
         description: |

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -181,8 +181,9 @@ definitions:
           to use in the new cluster
       availability_zones:
         description: |
-          Number of availability zones a cluster should be spread across. The
-          default is provided via the [info](#operation/getInfo) endpoint.
+          AWS - Stringified number of availability zones a cluster should be spread across.
+          Azure - A serialized list of availability zones a cluster should be spread across
+          The default is provided via the [info](#operation/getInfo) endpoint.
         type: string
       scaling:
         type: object

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -755,6 +755,10 @@ paths:
         configuration details, like worker node configuration, with node
         specification depending on the provider (e. g. on <span class="badge azure">Azure</span> the
         VM size, or on <span class="badge kvm">KVM</span> the memory size and number of CPU cores).
+        Availability zones are also different between providers (e. g. on
+        <span class="badge azure">Azure</span> the availability zones property
+        is a stringified list of the specific availability zones, but on
+        <span class="badge aws">AWS</span> it will be a stringified number)
 
         One attribute is __mandatory__ upon creation: The `owner`
         attribute must carry the name of the organization the cluster will
@@ -782,7 +786,7 @@ paths:
                 "owner": "myteam",
                 "release_version": "7.1.0",
                 "name": "Example cluster with 3 m5.xlarge nodes",
-                "availability_zones": 2,
+                "availability_zones": "2",
                 "scaling": {"min": 3, "max": 3},
                 "workers": [{"aws": {"instance_type": "m5.xlarge"}}]
               }


### PR DESCRIPTION
Epic: https://github.com/giantswarm/giantswarm/labels/Epic%3A%20Multi-AZ

To give a bit of context, we're adding multi-AZ support for Azure, which will not be automatic. The user will be able to pick which AZs he wants to use. While doing that, we also need to keep things compatible with the v4 way of setting availability zones.

My initial solution was creating a custom data structure for multi-AZ, with both a number and a list of zones to use. But after discussing with @oponder, we realized that this solution was not good, because it won't be backwards compatible.

The proposed change is to change the availability zones data type to a string, and for AWS clusters, there would be a single stringified number in there (e.g. `"2"`), but for Azure, we would have a serialized list of the AZs to use (e.g. `"2,4,5`).

As for handling the data differently for AWS and Azure, I suppose this should happen in `clusterclient`, where there would be different requests properties setup for AWS and Azure AZs.

As for supporting legacy requests, with availability zones set as integers, [we can do something like this](https://play.golang.org/p/6ZPsK0VQQvu), which will support both integers and strings.