### PR TITLE
Add v5 app endpoints

### DIFF
--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1176,7 +1176,7 @@ paths:
 
   /v4/clusters/{cluster_id}/apps/:
     get:
-      operationId: getClusterApps
+      operationId: getClusterAppsV4
       tags:
         - apps
       summary: Get a list of apps on a cluster (v4)
@@ -1268,7 +1268,7 @@ paths:
 
   /v4/clusters/{cluster_id}/apps/{app_name}/:
     delete:
-      operationId: deleteClusterApp
+      operationId: deleteClusterAppV4
       tags:
         - apps
       summary: Delete an app (v4)
@@ -1310,7 +1310,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     put:
-      operationId: createClusterApp
+      operationId: createClusterAppV4
       tags:
         - apps
       summary: Install an app (v4)
@@ -1447,7 +1447,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterApp
+      operationId: modifyClusterAppV4
       tags:
         - apps
       summary: Modify an app (v4)
@@ -1515,7 +1515,7 @@ paths:
 
   /v4/clusters/{cluster_id}/apps/{app_name}/config/:
     get:
-      operationId: getClusterAppConfig
+      operationId: getClusterAppConfigV4
       tags:
         - app configs
       summary: Get app config (v4)
@@ -1560,7 +1560,7 @@ paths:
                 "message": "Unable to show app config. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
               }
     put:
-      operationId: createClusterAppConfig
+      operationId: createClusterAppConfigV4
       tags:
         - app configs
       summary: Create app config (v4)
@@ -1653,7 +1653,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
     delete:
-      operationId: deleteClusterAppConfig
+      operationId: deleteClusterAppConfigV4
       tags:
         - app configs
       summary: Delete an app config (v4)
@@ -1704,7 +1704,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterAppConfig
+      operationId: modifyClusterAppConfigV4
       tags:
         - app configs
       summary: Modify app config (v4)
@@ -1791,7 +1791,7 @@ paths:
 
   /v4/clusters/{cluster_id}/apps/{app_name}/secret/:
     get:
-      operationId: getClusterAppSecret
+      operationId: getClusterAppSecretV4
       tags:
         - app secrets
       summary: Get Secret (v4)
@@ -1829,7 +1829,7 @@ paths:
                 "message": "Unable to show Secret. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
               }
     put:
-      operationId: createClusterAppSecret
+      operationId: createClusterAppSecretV4
       tags:
         - app secrets
       summary: Create Secret (v4)
@@ -1907,7 +1907,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
     delete:
-      operationId: deleteClusterAppSecret
+      operationId: deleteClusterAppSecretV4
       tags:
         - app secrets
       summary: Delete a Secret (v4)
@@ -1953,7 +1953,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterAppSecret
+      operationId: modifyClusterAppSecretV4
       tags:
         - app secrets
       summary: Modify Secret (v4)
@@ -2031,7 +2031,7 @@ paths:
 
   /v5/clusters/{cluster_id}/apps/:
     get:
-      operationId: getClusterApps
+      operationId: getClusterAppsV5
       tags:
         - apps
       summary: Get a list of apps on a cluster (v5)
@@ -2122,7 +2122,7 @@ paths:
 
   /v5/clusters/{cluster_id}/apps/{app_name}/:
     delete:
-      operationId: deleteClusterApp
+      operationId: deleteClusterAppV5
       tags:
         - apps
       summary: Delete an app (v5)
@@ -2164,7 +2164,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     put:
-      operationId: createClusterApp
+      operationId: createClusterAppV5
       tags:
         - apps
       summary: Install an app (v5)
@@ -2300,7 +2300,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterApp
+      operationId: modifyClusterAppV5
       tags:
         - apps
       summary: Modify an app (v5)
@@ -2366,7 +2366,7 @@ paths:
 
   /v5/clusters/{cluster_id}/apps/{app_name}/config/:
     get:
-      operationId: getClusterAppConfig
+      operationId: getClusterAppConfigV5
       tags:
         - app configs
       summary: Get app config (v5)
@@ -2410,7 +2410,7 @@ paths:
                 "message": "Unable to show app config. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
               }
     put:
-      operationId: createClusterAppConfig
+      operationId: createClusterAppConfigV5
       tags:
         - app configs
       summary: Create app config (v5)
@@ -2500,7 +2500,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
     delete:
-      operationId: deleteClusterAppConfig
+      operationId: deleteClusterAppConfigV5
       tags:
         - app configs
       summary: Delete an app config (v5)
@@ -2550,7 +2550,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterAppConfig
+      operationId: modifyClusterAppConfigV5
       tags:
         - app configs
       summary: Modify app config (v5)
@@ -2635,7 +2635,7 @@ paths:
 
   /v5/clusters/{cluster_id}/apps/{app_name}/secret/:
     get:
-      operationId: getClusterAppSecret
+      operationId: getClusterAppSecretV5
       tags:
         - app secrets
       summary: Get Secret (v5)
@@ -2672,7 +2672,7 @@ paths:
                 "message": "Unable to show Secret. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
               }
     put:
-      operationId: createClusterAppSecret
+      operationId: createClusterAppSecretV5
       tags:
         - app secrets
       summary: Create Secret (v5)
@@ -2748,7 +2748,7 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
     delete:
-      operationId: deleteClusterAppSecret
+      operationId: deleteClusterAppSecretV5
       tags:
         - app secrets
       summary: Delete a Secret (v5)
@@ -2793,7 +2793,7 @@ paths:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
     patch:
-      operationId: modifyClusterAppSecret
+      operationId: modifyClusterAppSecretV5
       tags:
         - app secrets
       summary: Modify Secret (v5)

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -2029,6 +2029,845 @@ paths:
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
 
+  /v5/clusters/{cluster_id}/apps/:
+    get:
+      operationId: getClusterApps
+      tags:
+        - apps
+      summary: Get a list of apps on a cluster (v5)
+      description: |
+        Returns an array of apps installed on a given cluster.
+
+        ### Example
+        ```json
+          [
+            {
+              "metadata": {
+                "name": "my-awesome-prometheus",
+                "labels": {}
+              },
+
+              "spec": {
+                "catalog": "sample-catalog"
+                "name": "prometheus-chart",
+                "namespace": "giantswarm",
+                "version": "0.2.0",
+                "user_config": {
+                  "configmap": {
+                    "name": "prometheus-user-values",
+                    "namespace": "123ab"
+                  }
+                }
+              },
+
+              "status": {
+                "app_version": "1.0.0",
+                "release": {
+                  "last_deployed": "2019-04-08T12:34:00Z",
+                  "status": "DEPLOYED"
+                },
+                "version": "0.2.0",
+              }
+            }
+          ]
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+      responses:
+        "200":
+          description: Cluster apps
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppsResponse"
+          examples:
+            application/json:
+              [
+                {
+                  "metadata": {
+                    "name": "my-awesome-prometheus",
+                    "labels": {},
+                  },
+
+                  "spec": {
+                    "catalog": "sample-catalog",
+                    "name": "prometheus-chart",
+                    "namespace": "giantswarm",
+                    "version": "0.2.0",
+                    "user_config": {
+                      "configmap": {
+                        "name": "prometheus-user-values",
+                        "namespace": "123ab"
+                      }
+                    }
+                  },
+
+                  "status": {
+                    "app_version": "1.0.0",
+                    "release": {
+                      "last_deployed": "2019-04-08T12:34:00Z",
+                      "status": "DEPLOYED"
+                    },
+                    "version": "0.2.0"
+                  }
+                }
+              ]
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v5/clusters/{cluster_id}/apps/{app_name}/:
+    delete:
+      operationId: deleteClusterApp
+      tags:
+        - apps
+      summary: Delete an app (v5)
+      description: |
+        This operation allows a user to delete an app.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+      responses:
+        "200":
+          description: App deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "Your app 'acme' on 'adc23' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "App could not be deleted. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    put:
+      operationId: createClusterApp
+      tags:
+        - apps
+      summary: Install an app (v5)
+      description: |
+        Install an app on a tenant cluster by posting to this endpoint.
+
+        The spec field represents the app we'll be installing, and so spec.name refers to
+        the name of the chart that installs this app in the catalog.
+
+        The response you get on a succesful create includes the status of the app. However
+        since the App is still initialising and this is an asynchronous operation, it is
+        likely that the fields in this status object will be all empty values.
+
+        To check on the status of your app, perform a GET to /v5/clusters/{cluster_id}/apps/,
+        and check the status field of the app.
+
+        ### Example PUT request
+        ```json
+          {
+            "spec": {
+              "catalog": "sample-catalog",
+              "name": "prometheus-chart",
+              "namespace": "prometheus",
+              "version": "0.2.0",
+            }
+          }
+        ```
+
+        ### About the user_config field in the response
+        This field is not editable by you, but is set automatically by the API
+        if a configmap named `{app_name}-user-values` exists in the tenant cluster
+        namespace on the control plane.
+
+        The `/v4/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows
+        you to create such a configmap using this API.
+
+        It is recommended to create your config before creating your app. This
+        will result in a faster deploy.
+
+        However, you can create your config after creating the app if you wish,
+        this API will take care of setting the `user_config` field of the app
+        correctly for you.
+
+        ### Why can't I just set the `user_config` value myself?
+        It simplifies usage while also being a security measure.
+
+        Furthermore it is also a security measure and ensures that users of this
+        API can't access arbitrary configmaps of the control plane.
+
+        This API will only allow you to edit or access configmaps that adhere
+        to a strict naming convention.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAppRequest"
+          x-examples:
+            application/json:
+              {
+                "spec": {
+                  "catalog": "sample-catalog",
+                  "name": "prometheus-chart",
+                  "namespace": "prometheus",
+                  "version": "0.2.0",
+                }
+              }
+      responses:
+        "200":
+          description: Create cluster app
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4App"
+          examples:
+            application/json:
+              {
+                "metadata": {
+                  "name": "my-awesome-prometheus",
+                },
+
+                "spec": {
+                  "catalog": "sample-catalog",
+                  "name": "prometheus-chart",
+                  "namespace": "giantswarm",
+                  "version": "0.2.0",
+                  "user_config": {
+                    "configmap": {
+                      "name": "prometheus-user-values",
+                      "namespace": "123ab"
+                    }
+                  }
+                },
+
+                "status": {
+                  "app_version": "",
+                  "release": {
+                    "last_deployed": "0000-00-00T00:00:00Z",
+                    "status": ""
+                  },
+                  "version": ""
+                }
+              }
+
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "App could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: App already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "An app with this name already exists."
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    patch:
+      operationId: modifyClusterApp
+      tags:
+        - apps
+      summary: Modify an app (v5)
+      description: |
+        This operation allows you to modify an existing app.
+
+        The following attributes can be modified:
+
+        - `version`: Changing this field lets you upgrade or downgrade an app.
+
+        `catalog`, `name`, `namespace`, and `user_config` are not editable. If you need to move or rename an app, you should instead delete the app and make it again.
+
+        The request body must conform with the [JSON Patch Merge (RFC 7386)](https://tools.ietf.org/html/rfc7386) standard.
+        Requests have to be sent with the `Content-Type: application/merge-patch+json` header.
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4ModifyAppRequest"
+          x-examples:
+            application/merge-patch+json:
+              {
+                "spec": {
+                  "version": "0.3.0",
+                }
+              }
+      responses:
+        "200":
+          description: App modified
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4App"
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "The app could not be modified. (invalid input: name is not an editable field)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The app could not be modified. (not found: the app with name 'my-great-app' could not be found)"
+              }
+        default:
+          description: error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v5/clusters/{cluster_id}/apps/{app_name}/config/:
+    get:
+      operationId: getClusterAppConfig
+      tags:
+        - app configs
+      summary: Get app config (v5)
+      description: |
+        This operation allows you to fetch the user values configmap associated
+        with an app.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppConfigResponse"
+          examples:
+            application/json:
+              {
+                "agent": {
+                  "key": "secret-key-here",
+                  "endpointHost": "saas-eu-west-1.instana.io",
+                  "endpointPort": "443",
+                },
+                "zone": {
+                  "name": "giantswarm-cluster"
+                }
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App Config not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Unable to show app config. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
+              }
+    put:
+      operationId: createClusterAppConfig
+      tags:
+        - app configs
+      summary: Create app config (v5)
+      description: |
+        This operation allows you to create a values configmap for a specific app. The app does
+        not have to exist before hand.
+
+        If the app does exist, this endpoint will ensure that the App CR gets it's
+        user_config field set correctly.
+
+        However, if the app exists and the user_config is already set to something,
+        then this request will fail. You will in that case most likely want to
+        update the config using the `PATCH /v5/clusters/{cluster_id}/apps/{app_name}/config/`
+        endpoint.
+
+        ### Example POST request
+        ```json
+          {
+            "agent": {
+              "key": "secret-key-here",
+              "endpointHost": "saas-eu-west-1.instana.io",
+              "endpointPort": "443",
+            },
+            "zone": {
+              "name": "giantswarm-cluster"
+            }
+          }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAppConfigRequest"
+          x-examples:
+            application/json:
+              {
+                "agent": {
+                  "key": "secret-key-here",
+                  "endpointHost": "saas-eu-west-1.instana.io",
+                  "endpointPort": "443",
+                },
+                "zone": {
+                  "name": "giantswarm-cluster"
+                }
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "App config for 'my-awesome-app' on 'abc12' has been created."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "App config could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: App config already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "A config for 'my-awesome-app' on 'abc12' already exists."
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    delete:
+      operationId: deleteClusterAppConfig
+      tags:
+        - app configs
+      summary: Delete an app config (v5)
+      description: |
+        This operation allows a user to delete an app's user config if it has been named according to the convention of {app-name}-user-values and
+        stored in the cluster ID namespace.
+
+        Calling this endpoint will delete the ConfigMap, but it does not remove the reference to the ConfigMap in the (spec.user_config.configmap field) from the app.
+
+        Do make sure you also update the app and remove the reference.
+
+        The preferred order is to first remove the reference to the configmap by
+        updating the app, and only then delete the configmap using this endpoint.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: './parameters.yaml#/parameters/ClusterIdPathParameter'
+        - $ref: './parameters.yaml#/parameters/AppNamePathParameter'
+      responses:
+        "200":
+          description: App Config deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "App config for 'my-app' on 'abc12' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: App Config not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The user config of app 'my-app' could not be deleted. ('my-app' not found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    patch:
+      operationId: modifyClusterAppConfig
+      tags:
+        - app configs
+      summary: Modify app config (v5)
+      description: |
+        This operation allows you to modify the values configmap for a specific app.
+        It's only possible to modify app configs that have been named according to the convention of
+        {app-name}-user-values and stored in the cluster ID namespace.
+
+        The full values key of the configmap will be replaced by the JSON body
+        of your request.
+
+        ### Example PATCH request
+        ```json
+          {
+            "agent": {
+              "key": "a-new-key-here",
+            }
+          }
+        ```
+
+        If the configmap contained content like:
+
+        ```json
+          {
+            "agent": {
+              "key": "an-old-key-here",
+              "admin": true,
+            },
+            "server": {
+              "url": "giantswarm.io",
+            }
+          }
+        ```
+
+        Then the "server" and "admin" keys will be removed.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateAppConfigRequest"
+          x-examples:
+            application/json:
+              {
+                "agent": {
+                  "key": "a-new-key-here",
+                }
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_UPDATED",
+                "message": "App config for 'my-awesome-app' on 'abc12' has been updated."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "App config could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+  /v5/clusters/{cluster_id}/apps/{app_name}/secret/:
+    get:
+      operationId: getClusterAppSecret
+      tags:
+        - app secrets
+      summary: Get Secret (v5)
+      description: |
+        This operation allows you to fetch the Secret associated
+        with an app.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GetClusterAppSecretResponse"
+          examples:
+            application/json:
+              {
+                "secret": "value"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Secret not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "Unable to show Secret. (app with name 'my-awesome-app' in cluster 'abc12' could not be found)"
+              }
+    put:
+      operationId: createClusterAppSecret
+      tags:
+        - app secrets
+      summary: Create Secret (v5)
+      description: |
+        This operation allows you to create a Secret for a specific app. The app does
+        not have to exist before hand.
+
+        If the app does exist, this endpoint will ensure that the App CR gets it's
+        `spec.user_config.secret` field set correctly.
+
+        However, if the app exists and the `spec.user_config.secret` is already set to something,
+        then this request will fail. You will in that case most likely want to
+        update the Secret using the `PATCH /v5/clusters/{cluster_id}/apps/{app_name}/secret/`
+        endpoint.
+
+        ### Example POST request
+        ```json
+          {
+            "secret": "value"
+          }
+        ```
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateClusterAppSecretRequest"
+          x-examples:
+            application/json:
+              {
+                "secret": "value"
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_CREATED",
+                "message": "Secret for 'my-awesome-app' on 'abc12' has been created."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "Secret could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "409":
+          description: Secret already exists
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_ALREADY_EXISTS",
+                "message": "A Secret for 'my-awesome-app' on 'abc12' already exists."
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+    delete:
+      operationId: deleteClusterAppSecret
+      tags:
+        - app secrets
+      summary: Delete a Secret (v5)
+      description: |
+        This operation allows a user to delete an app's Secret if it has been named according to the convention of {app-name}-user-secrets and
+        stored in the cluster ID namespace.
+
+        Calling this endpoint will delete the Secret, and also remove the reference to the Secret in the (spec.user_config.secret field) from the app.
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: './parameters.yaml#/parameters/ClusterIdPathParameter'
+        - $ref: './parameters.yaml#/parameters/AppNamePathParameter'
+      responses:
+        "200":
+          description: Secret deleted
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_DELETED",
+                "message": "Secret for 'my-app' on 'abc12' has been deleted."
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        "404":
+          description: Secret not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_NOT_FOUND",
+                "message": "The Secret of app 'my-app' could not be deleted. ('my-app' not found)"
+              }
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+    patch:
+      operationId: modifyClusterAppSecret
+      tags:
+        - app secrets
+      summary: Modify Secret (v5)
+      description: |
+        This operation allows you to modify the Secret for a specific app.
+        It's only possible to modify Secrets that have been named according to the convention of
+        {app-name}-user-secrets and stored in the cluster ID namespace.
+
+        The full values key of the Secret will be replaced by the JSON body
+        of your request.
+
+        ### Example PATCH request
+        ```json
+          {
+            "secret": "new-value"
+          }
+        ```
+
+        If the Secret contained content like:
+
+        ```json
+          {
+            "secret": "old-value",
+            "secret2": "another-old-value"
+          }
+        ```
+
+        Then the "secret2" will be removed, and "secret" will be set to "new-value"
+
+      parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
+        - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
+        - $ref: "./parameters.yaml#/parameters/AppNamePathParameter"
+        - name: body
+          in: body
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4CreateClusterAppSecretRequest"
+          x-examples:
+            application/json:
+              {
+                "secret": "new-value"
+              }
+
+      responses:
+        "200":
+          description: Success
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "RESOURCE_UPDATED",
+                "message": "Secret for 'my-awesome-app' on 'abc12' has been updated."
+              }
+        "400":
+          description: Invalid input
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_INPUT",
+                "message": "Secret could not be created. (invalid input)"
+              }
+        "401":
+          $ref: "./responses.yaml#/responses/V4Generic401Response"
+        default:
+          description: Error
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+
+
   /v4/organizations/:
     get:
       operationId: getOrganizations

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -1179,9 +1179,10 @@ paths:
       operationId: getClusterApps
       tags:
         - apps
-      summary: Get cluster apps
+      summary: Get a list of apps on a cluster (v4)
       description: |
         Returns an array of apps installed on a given cluster.
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         ### Example
         ```json
@@ -1270,9 +1271,10 @@ paths:
       operationId: deleteClusterApp
       tags:
         - apps
-      summary: Delete an app
+      summary: Delete an app (v4)
       description: |
         This operation allows a user to delete an app.
+        For apps on v5 clusters, please use the v5 version of this endpoint.
       parameters:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
@@ -1311,9 +1313,10 @@ paths:
       operationId: createClusterApp
       tags:
         - apps
-      summary: Install an app
+      summary: Install an app (v4)
       description: |
         Install an app on a tenant cluster by posting to this endpoint.
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         The spec field represents the app we'll be installing, and so spec.name refers to
         the name of the chart that installs this app in the catalog.
@@ -1447,9 +1450,11 @@ paths:
       operationId: modifyClusterApp
       tags:
         - apps
-      summary: Modify an app
+      summary: Modify an app (v4)
       description: |
         This operation allows you to modify an existing app.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         The following attributes can be modified:
 
@@ -1513,10 +1518,12 @@ paths:
       operationId: getClusterAppConfig
       tags:
         - app configs
-      summary: Get app config
+      summary: Get app config (v4)
       description: |
         This operation allows you to fetch the user values configmap associated
         with an app.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
       parameters:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
@@ -1556,7 +1563,7 @@ paths:
       operationId: createClusterAppConfig
       tags:
         - app configs
-      summary: Create app config
+      summary: Create app config (v4)
       description: |
         This operation allows you to create a values configmap for a specific app. The app does
         not have to exist before hand.
@@ -1568,6 +1575,8 @@ paths:
         then this request will fail. You will in that case most likely want to
         update the config using the `PATCH /v4/clusters/{cluster_id}/apps/{app_name}/config/`
         endpoint.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
 
         ### Example POST request
@@ -1647,7 +1656,7 @@ paths:
       operationId: deleteClusterAppConfig
       tags:
         - app configs
-      summary: Delete an app config
+      summary: Delete an app config (v4)
       description: |
         This operation allows a user to delete an app's user config if it has been named according to the convention of {app-name}-user-values and
         stored in the cluster ID namespace.
@@ -1658,6 +1667,8 @@ paths:
 
         The preferred order is to first remove the reference to the configmap by
         updating the app, and only then delete the configmap using this endpoint.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
       parameters:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
@@ -1696,7 +1707,7 @@ paths:
       operationId: modifyClusterAppConfig
       tags:
         - app configs
-      summary: Modify app config
+      summary: Modify app config (v4)
       description: |
         This operation allows you to modify the values configmap for a specific app.
         It's only possible to modify app configs that have been named according to the convention of
@@ -1704,6 +1715,8 @@ paths:
 
         The full values key of the configmap will be replaced by the JSON body
         of your request.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         ### Example PATCH request
         ```json
@@ -1781,10 +1794,12 @@ paths:
       operationId: getClusterAppSecret
       tags:
         - app secrets
-      summary: Get Secret
+      summary: Get Secret (v4)
       description: |
         This operation allows you to fetch the Secret associated
         with an app.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
       parameters:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
@@ -1817,7 +1832,7 @@ paths:
       operationId: createClusterAppSecret
       tags:
         - app secrets
-      summary: Create Secret
+      summary: Create Secret (v4)
       description: |
         This operation allows you to create a Secret for a specific app. The app does
         not have to exist before hand.
@@ -1830,6 +1845,7 @@ paths:
         update the Secret using the `PATCH /v4/clusters/{cluster_id}/apps/{app_name}/secret/`
         endpoint.
 
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         ### Example POST request
         ```json
@@ -1894,12 +1910,14 @@ paths:
       operationId: deleteClusterAppSecret
       tags:
         - app secrets
-      summary: Delete a Secret
+      summary: Delete a Secret (v4)
       description: |
         This operation allows a user to delete an app's Secret if it has been named according to the convention of {app-name}-user-secrets and
         stored in the cluster ID namespace.
 
         Calling this endpoint will delete the Secret, and also remove the reference to the Secret in the (spec.user_config.secret field) from the app.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
       parameters:
         - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
         - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
@@ -1938,7 +1956,7 @@ paths:
       operationId: modifyClusterAppSecret
       tags:
         - app secrets
-      summary: Modify Secret
+      summary: Modify Secret (v4)
       description: |
         This operation allows you to modify the Secret for a specific app.
         It's only possible to modify Secrets that have been named according to the convention of
@@ -1946,6 +1964,8 @@ paths:
 
         The full values key of the Secret will be replaced by the JSON body
         of your request.
+
+        For apps on v5 clusters, please use the v5 version of this endpoint.
 
         ### Example PATCH request
         ```json


### PR DESCRIPTION
This adds the family of `v5/clusters/{cluster_id}/apps` endpoints to the spec, which are being implemented here: https://github.com/giantswarm/api/pull/965
