### PR TITLE
Fix chart parameter in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
           name: "package and push api-spec"
           app_catalog: "giantswarm-operations-platform-catalog"
           app_catalog_test: "giantswarm-operations-platform-test-catalog"
-          chart: "api-spec-app"
+          chart: "api-spec"
           # Trigger job on git tag.
           filters:
             tags:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7349

Rempves the `-app` ending from the chart attribute, as described in https://github.com/giantswarm/giantswarm/blob/d3901d6d798fb2d51b35f0e6e97f845054887625/areas/managed-services/adding_app_to_appcatalog.md