### PR TITLE
Add ServiceAccount, Role, RoleBinding, and PSP for using EmptyDir

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ workflows:
   package-and-push-chart-on-tag:
     jobs:
       - build:
-          filters:  # required since `rchitect/push-to-app-catalog` has tag filters AND requires `build`
+          filters:  # required since `architect/push-to-app-catalog` has tag filters AND requires `build`
             tags:
               only: /.*/
       - architect/push-to-app-catalog:

--- a/helm/api-spec-app/Chart.yaml
+++ b/helm/api-spec-app/Chart.yaml
@@ -4,4 +4,4 @@ namespace: docs
 appVersion: 0.0.1
 description: Serves the ReDoc container with the documentation of the GS API.
 home: https://github.com/giantswarm/api-spec
-version: [[ .Version ]]
+version: "[[ .Version ]]"

--- a/helm/api-spec-app/Chart.yaml
+++ b/helm/api-spec-app/Chart.yaml
@@ -4,4 +4,4 @@ namespace: docs
 appVersion: 0.0.1
 description: Serves the ReDoc container with the documentation of the GS API.
 home: https://github.com/giantswarm/api-spec
-version: "[[ .Version ]]"
+version: "[[.Version]]"

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   replicas: 2
   revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
   template:
     metadata:
       labels:

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.namespace }}
   labels:
     app: {{ .Values.name }}
 

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           # This is a public image, so no pullsecret required
-          image: quay.io/giantswarm/{{ .Values.name }}:latest
+          image: quay.io/giantswarm/{{ .Values.name }}:{{ .Values.image.tag }}
           ports:
             - containerPort: 8000
           volumeMounts:

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Values.name }}
 
@@ -20,7 +20,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           # This is a public image, so no pullsecret required
-          image: quay.io/giantswarm/{{ .Values.name }}:{{ .Values.image.tag }}
+          image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.tag }}
           ports:
             - containerPort: 8000
           volumeMounts:

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       containers:
         - name: {{ .Values.name }}
           # This is a public image, so no pullsecret required
-          image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.tag }}
+          image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.sha }}
           ports:
             - containerPort: 8000
           volumeMounts:

--- a/helm/api-spec-app/templates/deployment.yaml
+++ b/helm/api-spec-app/templates/deployment.yaml
@@ -29,3 +29,5 @@ spec:
       volumes:
       - name: cache-volume
         emptyDir: {}
+      serviceAccount: {{ .Values.name }}
+      serviceAccountName: {{ .Values.name }}

--- a/helm/api-spec-app/templates/psp-rbac.yaml
+++ b/helm/api-spec-app/templates/psp-rbac.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+    name: {{ .Values.name }}
+spec:
+    allowPrivilegeEscalation: false
+    fsGroup:
+    ranges:
+    - max: 65535
+        min: 1
+    rule: MustRunAs
+    runAsUser:
+    rule: MustRunAsNonRoot
+    seLinux:
+    rule: RunAsAny
+    supplementalGroups:
+    ranges:
+    - max: 65535
+        min: 1
+    rule: MustRunAs
+    volumes:
+    - secret
+    - configMap
+    - emptyDir
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    namespace: {{ .Release.Namespace }}
+    name: {{ .Values.name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: {{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+    - extensions
+    resourceNames:
+    - {{ .Values.name }}
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: {{ .Values.name }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: {{ .Values.name }}
+subjects:
+- kind: ServiceAccount
+    name: {{ .Values.name }}
+    namespace: {{ .Release.Namespace }}

--- a/helm/api-spec-app/templates/psp-rbac.yaml
+++ b/helm/api-spec-app/templates/psp-rbac.yaml
@@ -2,23 +2,23 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-    name: {{ .Values.name }}
-spec:
+  name: {{ .Values.name }}
+  spec:
     allowPrivilegeEscalation: false
     fsGroup:
-    ranges:
-    - max: 65535
+      ranges:
+      - max: 65535
         min: 1
-    rule: MustRunAs
+      rule: MustRunAs
     runAsUser:
-    rule: MustRunAsNonRoot
+      rule: MustRunAsNonRoot
     seLinux:
-    rule: RunAsAny
+      rule: RunAsAny
     supplementalGroups:
-    ranges:
-    - max: 65535
+      ranges:
+      - max: 65535
         min: 1
-    rule: MustRunAs
+      rule: MustRunAs
     volumes:
     - secret
     - configMap
@@ -27,34 +27,34 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-    namespace: {{ .Release.Namespace }}
-    name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-    name: {{ .Values.name }}
-    namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
 rules:
 - apiGroups:
-    - extensions
-    resourceNames:
-    - {{ .Values.name }}
-    resources:
-    - podsecuritypolicies
-    verbs:
-    - use
+  - extensions
+  resourceNames:
+  - {{ .Values.name }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-    name: {{ .Values.name }}
-    namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}
 roleRef:
-    apiGroup: rbac.authorization.k8s.io
-    kind: Role
-    name: {{ .Values.name }}
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Values.name }}
 subjects:
 - kind: ServiceAccount
-    name: {{ .Values.name }}
-    namespace: {{ .Release.Namespace }}
+  name: {{ .Values.name }}
+  namespace: {{ .Release.Namespace }}

--- a/helm/api-spec-app/templates/psp-rbac.yaml
+++ b/helm/api-spec-app/templates/psp-rbac.yaml
@@ -1,28 +1,28 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ .Values.name }}
-  spec:
-    allowPrivilegeEscalation: false
-    fsGroup:
-      ranges:
-      - max: 65535
-        min: 1
-      rule: MustRunAs
-    runAsUser:
-      rule: MustRunAsNonRoot
-    seLinux:
-      rule: RunAsAny
-    supplementalGroups:
-      ranges:
-      - max: 65535
-        min: 1
-      rule: MustRunAs
-    volumes:
-    - secret
-    - configMap
-    - emptyDir
+spec:
+  allowPrivilegeEscalation: false
+  runAsUser:
+    rule: MustRunAsNonRoot
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: MustRunAs
+    ranges:
+    - max: 65535
+      min: 1
+  fsGroup:
+    rule: MustRunAs
+    ranges:
+    - max: 65535
+      min: 1
+  volumes:
+  - secret
+  - configMap
+  - emptyDir
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/helm/api-spec-app/templates/service.yaml
+++ b/helm/api-spec-app/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.name }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.Namespace }}
   labels:
     app: {{ .Values.name }}
 

--- a/helm/api-spec-app/values.yaml
+++ b/helm/api-spec-app/values.yaml
@@ -3,3 +3,4 @@ namespace: docs
 image:
   name: api-spec
   tag: "[[.Version]]"
+  sha: "[[.SHA]]"

--- a/helm/api-spec-app/values.yaml
+++ b/helm/api-spec-app/values.yaml
@@ -1,0 +1,5 @@
+name: api-spec-app
+namespace: docs
+image:
+  name: api-spec
+  tag: "[[ .Version ]]"

--- a/helm/api-spec-app/values.yaml
+++ b/helm/api-spec-app/values.yaml
@@ -2,4 +2,4 @@ name: api-spec-app
 namespace: docs
 image:
   name: api-spec
-  tag: "[[ .Version ]]"
+  tag: "[[.Version]]"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7349

**This PR does not contain any changes regarding the Giant Swarm API specification. The focus is on the technicalities of publishing the documentation.**

This PR should enable the app to use an EmptyDir volume for the nginx cache. It's derived from the working docs deployment in gollum/35ac3.