### PR TITLE
Add 400 error for invalid instance type

### DIFF
--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -815,7 +815,7 @@ paths:
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
         "400":
-          description: Instance type not found
+          description: Invalid request
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
           examples:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -3534,7 +3534,7 @@ paths:
                 "nodepools": []
               }
         "400":
-          description: Instance type not found
+          description: Invalid request
           schema:
             $ref: "./definitions.yaml#/definitions/V4GenericResponse"
           examples:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -814,6 +814,16 @@ paths:
                 "code": "RESOURCE_CREATED",
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
+        "400":
+          description: Instance type not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_REQUEST",
+                "message": "The instance type 'm6.superb' does not exist or is unknown."
+              }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
@@ -3522,6 +3532,16 @@ paths:
                   "availability_zone": "europe-central-1c"
                 },
                 "nodepools": []
+              }
+        "400":
+          description: Instance type not found
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_REQUEST",
+                "message": "The instance type 'm6.superb' does not exist or is unknown."
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/3046

This adds a 400 status code error in case the provided instance type while creating a cluster is not supported.