### PR TITLE
Update spec for master nodes high availability

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1202,6 +1202,7 @@ definitions:
             type: array
             description: |
               Availability zones of the master node(s) of this cluster.
+            x-nullable: true
             items:
               type: string
           num_ready:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -105,6 +105,13 @@ definitions:
               release_version_minimum:
                 type: string
                 description: The minimum release version number required to have support for node pools.
+          spot_instances:
+            type: object
+            description: Allows to use cheaper spot instances instead of on-demand EC2 instances.
+            properties:
+              release_version_minimum:
+                type: string
+                description: The minimum release version number required to have support for spot instances.
       stats:
         type: object
         description: Statistics about the installation
@@ -886,6 +893,7 @@ definitions:
           Specifies how the nodes of a pool are spread over availability zones.
           The object must contain either the `number` attribute or the `zones`
           attribute, but not both.
+
           The maximum `number` of availbility zones is the same as that found
           under `general.availability_zones.max` from the `/v4/info/` endpoint.
           When not given, availability zones assignment is handled automatically.
@@ -930,10 +938,43 @@ definitions:
         description: |
           Attributes specific to the AWS provider
         properties:
+          instance_distribution:
+            description: |
+              Attributes defining the instance distribution in the node pool being created.
+              Added with AWS release v11.2.0.
+            type: object
+            properties:
+              on_demand_base_capacity:
+                description: |
+                  Base capacity of on-demand EC2 instances to use for worker nodes in this pools.
+                  When this is larger than 0, this value defines a number of worker nodes that
+                  will be created using on-demand EC2 instances, regardless of the value
+                  configured as `on_demand_percentage_above_base_capacity`.
+                type: integer
+                minimum: 0
+                default: 0
+              on_demand_percentage_above_base_capacity:
+                description: |
+                  Percentage of on-demand EC2 instances to use for worker nodes, instead of spot
+                  instances, for instances exceeding `on_demand_base_capacity`. For example, to
+                  have half of the worker nodes use spot instances and half use on-demand, set this
+                  value to 50.
+                type: integer
+                minimum: 0
+                maximum: 100
+                default: 100
           instance_type:
             type: string
             description: |
               EC2 instance type to use for all nodes in the node pool. _(Validated against available instance types.)_
+          use_alike_instance_types:
+            type: boolean
+            default: false
+            description: |
+              If true, instance types alike the type set via `instance_type` will be used. This can
+              increase the likelihood to get instances for this pool, especially spot instances at
+              a low rate. If false, only the exact type set as `instance_type` is used.
+              Added with AWS release v11.2.0.
 
   # Specification of a node in a node pool after creation
   V5GetNodePoolResponseNodeSpec:
@@ -944,10 +985,31 @@ definitions:
         description: |
           Attributes specific to the AWS provider
         properties:
+          instance_distribution:
+            description: |
+              Attributes defining the instance distribution in a node pool.
+            type: object
+            properties:
+              on_demand_base_capacity:
+                description: |
+                  Base capacity of on-demand EC2 instances to use for worker nodes in this pools.
+                  Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
+                type: integer
+              on_demand_percentage_above_base_capacity:
+                description: |
+                  Percentage of on-demand EC2 instances to use for worker nodes, instead of spot
+                  instances, for instances exceeding `on_demand_base_capacity`.
+                  Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
+                type: integer
           instance_type:
             type: string
             description: |
-              EC2 instance type used by all nodes in this pool
+              EC2 instance type used by all nodes in this pool.
+          use_alike_instance_types:
+            type: boolean
+            description: |
+              Whether this node pool can use different instance types alike the configured one.
+              Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
       volume_sizes_gb:
         type: object
         properties:
@@ -1002,11 +1064,21 @@ definitions:
         description: Information on the current size and status of the node pool
         type: object
         properties:
+          instance_types:
+            description: Instance types currently in use in this node pool.
+            type: array
+            items:
+              description: EC2 instance type identifier
+              type: string
           nodes:
-            description: Desired number of nodes in the pool
+            description: Desired number of nodes in the pool according to the
+              cluster-autoscaler
             type: integer
           nodes_ready:
             description: Number of nodes in state NodeReady
+            type: integer
+          spot_instances:
+            description: Number of instances with lifecycle spot
             type: integer
 
 

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1134,13 +1134,13 @@ definitions:
             description: |
               Specifies whether or not this cluster should run with redundant master
               nodes (high availability).
-              
+
               When `true`, three master nodes will be started, each one in a different
               availability zone that is selected randomly. This is the recommended
               setting for production clusters. However, note that this is only
               available on <span class="badge aws">AWS</span> starting with release v11.4.0.
-              
-              When `false`, only one master node will be created, also in a randomly 
+
+              When `false`, only one master node will be created, also in a randomly
               selected availability zone.
   V5ClusterDetailsResponse:
     type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1209,7 +1209,7 @@ definitions:
             type: integer
             description: |
               Number of master nodes that are reported as `Ready`.
-            format: int32
+            format: int8
             x-nullable: true
       conditions:
         type: array

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -98,6 +98,13 @@ definitions:
         type: object
         description: Information on particular capabilities of the installation.
         properties:
+          ha_masters:
+            type: object
+            description: Support for multiple master nodes.
+            properties:
+              release_version_minimum:
+                type: string
+                description: The minimum release version number required to have support for multiple master nodes.
           nodepools:
             type: object
             description: Support for grouping of worker nodes into node pools.

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1105,7 +1105,12 @@ definitions:
         type: object
         description: |
           Configuration regarding the master node. If not given, the master node
-          will be placed automatically.
+          will be placed automatically. Must not be used together with
+          the `master_nodes` property.
+
+          *Deprecation notice:* This property has been replaced by `master_nodes`
+          and is deprecated. It will still be accepted in requests until
+          July 30, 2020. After that, using it will issue an error `400 Bad Request`.
         properties:
           availability_zone:
             type: string
@@ -1164,7 +1169,11 @@ definitions:
       master:
         type: object
         description: |
-          Information about the master node
+          Legacy information about the master node.
+
+          *Deprecation notice:* This attribute is replaced by `master_nodes`.
+          It will be served until July 30, 2020 in the case that the cluster
+          specification has one master node only.
         properties:
           availability_zone:
             type: string

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1181,6 +1181,7 @@ definitions:
           *Deprecation notice:* This attribute is replaced by `master_nodes`.
           It will be served until July 30, 2020 in the case that the cluster
           specification has one master node only.
+        x-nullable: true
         properties:
           availability_zone:
             type: string
@@ -1190,6 +1191,7 @@ definitions:
         type: object
         description: |
           Information on the master node(s) of this cluster
+        x-nullable: true
         properties:
           high_availability:
             type: boolean
@@ -1206,6 +1208,7 @@ definitions:
             type: integer
             description: |
               Number of master nodes that are reported as `Ready`.
+            x-nullable: true
       conditions:
         type: array
         description: List of conditions the cluster has gone through

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1202,6 +1202,10 @@ definitions:
               Availability zones of the master node(s) of this cluster.
             items:
               type: string
+          num_ready:
+            type: integer
+            description: |
+              Number of master nodes that are reported as `Ready`.
       conditions:
         type: array
         description: List of conditions the cluster has gone through

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1133,11 +1133,15 @@ definitions:
             default: true
             description: |
               Specifies whether or not this cluster should run with redundant master
-              nodes (high availability). When true, three master nodes will be started,
-              each one in a different availability zone that is selected randomly.
-              This is the recommended setting for production clusters. When false, only
-              one master node will be created, also in a randomly selected availability
-              zone.
+              nodes (high availability).
+              
+              When `true`, three master nodes will be started, each one in a different
+              availability zone that is selected randomly. This is the recommended
+              setting for production clusters. However, note that this is only
+              available on <span class="badge aws">AWS</span> starting with release v11.4.0.
+              
+              When `false`, only one master node will be created, also in a randomly 
+              selected availability zone.
   V5ClusterDetailsResponse:
     type: object
     properties:
@@ -1224,6 +1228,7 @@ definitions:
               description: A string describing the condition, e. g. 'Created'
       versions:
         type: array
+        description: List of release versions the cluster has used.
         items:
           type: object
           properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1242,6 +1242,17 @@ definitions:
       release_version:
         type: string
         description: Release version to upgrade to
+      master_nodes:
+        type: object
+        properties:
+          high_availability:
+            description: |
+              Setting this attribute to `true` allows to switch a cluster from
+              using a single master node to multiple (3) master nodes in
+              separate availability zones for high availability. Note that the
+              switch from multiple master nodes to a single master node is not
+              supported.
+            type: boolean
 
   V5ModifyNodePoolRequest:
     type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1117,7 +1117,7 @@ definitions:
 
           *Deprecation notice:* This property has been replaced by `master_nodes`
           and is deprecated. It will still be accepted in requests until
-          July 30, 2020. After that, using it will issue an error `400 Bad Request`.
+          August 31, 2020. After that, using it will issue an error `400 Bad Request`.
         properties:
           availability_zone:
             type: string
@@ -1179,7 +1179,7 @@ definitions:
           Legacy information about the master node.
 
           *Deprecation notice:* This attribute is replaced by `master_nodes`.
-          It will be served until July 30, 2020 in the case that the cluster
+          It will be served until August 31, 2020 in the case that the cluster
           specification has one master node only.
         x-nullable: true
         properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1112,7 +1112,21 @@ definitions:
             description: |
               Name of the availability zone to use for the master node. If not
               given, the master node will be placed automatically.
-
+      master_nodes:
+        type: object
+        description: |
+          Defines how many master nodes the cluster should have.
+        properties:
+          high_availability:
+            type: boolean
+            default: true
+            description: |
+              Specifies whether or not this cluster should run with redundant master
+              nodes (high availability). When true, three master nodes will be started,
+              each one in a different availability zone that is selected randomly.
+              This is the recommended setting for production clusters. When false, only
+              one master node will be created, also in a randomly selected availability
+              zone.
   V5ClusterDetailsResponse:
     type: object
     properties:
@@ -1156,6 +1170,22 @@ definitions:
             type: string
             description: |
               Name of the availability zone the master node is placed in
+      master_nodes:
+        type: object
+        description: |
+          Information on the master node(s) of this cluster
+        properties:
+          high_availability:
+            type: boolean
+            description: |
+              When true, the cluster has (or should have) three master nodes.
+              Otherwise it should have one.
+          availability_zones:
+            type: array
+            description: |
+              Availability zones of the master node(s) of this cluster.
+            items:
+              type: string
       conditions:
         type: array
         description: List of conditions the cluster has gone through

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1111,9 +1111,8 @@ definitions:
       master:
         type: object
         description: |
-          Configuration regarding the master node. If not given, the master node
-          will be placed automatically. Must not be used together with
-          the `master_nodes` property.
+          Legacy configuration regarding the master node. Must not be used
+          together with the `master_nodes` property.
 
           *Deprecation notice:* This property has been replaced by `master_nodes`
           and is deprecated. It will still be accepted in requests until
@@ -1179,8 +1178,8 @@ definitions:
           Legacy information about the master node.
 
           *Deprecation notice:* This attribute is replaced by `master_nodes`.
-          It will be served until August 31, 2020 in the case that the cluster
-          specification has one master node only.
+          It will be served for compatibility reasons until August 31, 2020
+          in the case that the cluster specification has one master node only.
         x-nullable: true
         properties:
           availability_zone:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1209,6 +1209,7 @@ definitions:
             type: integer
             description: |
               Number of master nodes that are reported as `Ready`.
+            format: int32
             x-nullable: true
       conditions:
         type: array

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -246,7 +246,7 @@ paths:
           },
           "workers": {
             "count_per_cluster": {
-              "max": null,
+              "max": 999,
               "default": 3
             },
             "instance_type": {
@@ -325,7 +325,7 @@ paths:
                 },
                 "workers": {
                   "count_per_cluster": {
-                    "max": null,
+                    "max": 999,
                     "default": 3
                   },
                   "instance_type": {

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -3512,8 +3512,8 @@ paths:
                 "owner": "myteam",
                 "release_version": "11.0.0",
                 "name": "Production cluster using k8s 1.16",
-                "master": {
-                  "availability_zone": "europe-central-1c"
+                "master_nodes": {
+                  "high_availability": "true"
                 }
               }
       responses:
@@ -3528,8 +3528,9 @@ paths:
                 "owner": "myteam",
                 "release_version": "11.0.0",
                 "name": "Production cluster using k8s 1.16",
-                "master": {
-                  "availability_zone": "europe-central-1c"
+                "master_nodes": {
+                  "high_availability": true,
+                  "availability_zones": ["europe-central-1a", "europe-central-1c", "europe-central-1d"]
                 },
                 "nodepools": []
               }

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -3609,14 +3609,19 @@ paths:
             application/json:
               {
                 "id": "7g4di",
-                "create_date": "2019-06-01T12:00:13.949270905Z",
+                "create_date": "2020-06-16T12:00:13.949270905Z",
                 "api_endpoint": "https://api.k8s.7g4di.example.com",
-                "name": "All purpose cluster",
-                "release_version": "11.0.0",
+                "name": "Production cluster",
+                "release_version": "11.4.0",
                 "owner": "acme",
                 "credential_id": "a1b2c",
                 "master": {
                   "availability_zone": "europe-west-1c"
+                },
+                "master_nodes": {
+                  "high_availability": true,
+                  "availability_zones": ["europe-west-1c", "europe-west-1a", "europe-west-1b"],
+                  "num_ready": 3
                 },
                 "conditions": [
                   {
@@ -3634,7 +3639,7 @@ paths:
                   "aws-operator.giantswarm.io/version":"8.1.1",
                   "giantswarm.io/cluster":"7g4di",
                   "giantswarm.io/organization":"acme",
-                  "release.giantswarm.io/version":"11.0.0"
+                  "release.giantswarm.io/version":"11.4.0"
                 }
               }
         "301":

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -814,6 +814,16 @@ paths:
                 "code": "RESOURCE_CREATED",
                 "message": "A new cluster has been created with ID 'wqtlq'"
               }
+        "400":
+          description: Invalid request
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_REQUEST",
+                "message": "The instance type 'm6.superb' does not exist or is unknown."
+              }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"
         default:
@@ -3522,6 +3532,16 @@ paths:
                   "availability_zone": "europe-central-1c"
                 },
                 "nodepools": []
+              }
+        "400":
+          description: Invalid request
+          schema:
+            $ref: "./definitions.yaml#/definitions/V4GenericResponse"
+          examples:
+            application/json:
+              {
+                "code": "INVALID_REQUEST",
+                "message": "The instance type 'm6.superb' does not exist or is unknown."
               }
         "401":
           $ref: "./responses.yaml#/responses/V4Generic401Response"


### PR DESCRIPTION
For [HA Masters](https://github.com/giantswarm/roadmap/issues/58). Closes https://github.com/giantswarm/giantswarm/issues/7901

## Notable changes

- For v5 cluster creation, the `master` property gets deprecated, to be replaced by the new `master_nodes` property. There will be a deprecation phase where the old form can still be used to create clusters with single master nodes.
- For getting v5 cluster details, likewise the `master` property gets deprecated, eventually to be replaced by the new `master_nodes` property. During the deprecation phase, both properties will be served in case the cluster has only one master node.
- The `modifyClusterV5` request body is changed to support the switch from single to HA masters.