### PR TITLE
Fix some mistakes of the original cluster labelling PR

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1214,6 +1214,14 @@ definitions:
             description: Maximum number of nodes in the pool
             type: integer
 
+  V5SetClusterLabelsRequest:
+    type: object
+    description: Cluster labels
+    additionalProperties: false
+    properties:
+      labels:
+        $ref: "./definitions.yaml#/definitions/V5ClusterLabels"
+
   # cluster labels response
   V5ClusterLabelsResponse:
     type: object
@@ -1233,7 +1241,7 @@ definitions:
       title: Labels
       description: Key value pairs representing the labels attached to the cluster
 
-  V5ListClustersByLabel:
+  V5ListClustersByLabelRequest:
     type: object
     required:
       - labels

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -3993,6 +3993,9 @@ paths:
       description: |
         Returns the labels that this cluster is labelled with
       parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
         - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
       responses:
         "200":
@@ -4035,13 +4038,16 @@ paths:
         changes to label `release.giantswarm.io/version`
         will be validated against available Giant Swarm releases.
       parameters:
+        - $ref: './parameters.yaml#/parameters/XRequestIDHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmActivityHeader'
+        - $ref: './parameters.yaml#/parameters/XGiantSwarmCmdLineHeader'
         - $ref: "./parameters.yaml#/parameters/ClusterIdPathParameter"
         - name: body
           in: body
           required: true
           description: Labels to attach to this cluster.
           schema:
-            $ref: "./definitions.yaml#/definitions/V5ClusterLabelsResponse"
+            $ref: "./definitions.yaml#/definitions/V5SetClusterLabelsRequest"
           x-examples:
             application/json:
               {
@@ -4107,7 +4113,7 @@ paths:
           required: true
           description: Label selector
           schema:
-            $ref: "./definitions.yaml#/definitions/V5ListClustersByLabel"
+            $ref: "./definitions.yaml#/definitions/V5ListClustersByLabelRequest"
           x-examples:
             application/json:
               {


### PR DESCRIPTION
Follow-up to #196 

Improvements over #196:

- Adds the usual header parameters to `getClusterLabels` & `setClusterLabels`
- Adds separate Request definition. Right now Request & Response share one definition which is confusing in generated clients IMO
- Renaming of `V5ListClustersByLabel` to make it clear it is a Request definition