### PR TITLE
Add Azure specific fields to V5GetNodePoolResponseNodeSpec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.4.3
+  architect: giantswarm/architect@0.10.0
 
 jobs:
   build:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -999,6 +999,7 @@ definitions:
               Azure virtual machine size used by all nodes in this pool.
       aws:
         type: object
+        x-nullable: true
         description: |
           Attributes specific to the AWS provider
         properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -989,6 +989,7 @@ definitions:
     properties:
       azure:
         type: object
+        x-nullable: true
         description: |
           Attributes specific to the Azure provider
         properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -987,6 +987,15 @@ definitions:
   V5GetNodePoolResponseNodeSpec:
     type: object
     properties:
+      azure:
+        type: object
+        description: |
+          Attributes specific to the Azure provider
+        properties:
+          vm_size:
+            type: string
+            description: |
+              Azure virtual machine size used by all nodes in this pool.
       aws:
         type: object
         description: |


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/9.

What's in the box:
- Adding Azure-specific fields to the API response when listing node pools