### PR TITLE
Add end-of-life date to releases response

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -668,11 +668,18 @@ definitions:
       labels:
         $ref: "./definitions.yaml#/definitions/V5ClusterLabelsProperty"
 
-  # A cluster array item, as return by getClusters
+  # A release array item, as return by getReleases
   V4ReleaseListItem:
     type: object
     required: ["version", "timestamp", "changelog", "components"]
     properties:
+      eol_date:
+        type: string
+        format: date-time
+        description: |
+          End-of-life date and time. After this date/time, a cluster
+          using this release will no longer be supported by Giant
+          Swarm.
       version:
         type: string
         description: The semantic version number

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -3471,6 +3471,7 @@ paths:
                 {
                   "version": "1.14.9",
                   "timestamp": "2017-09-21T08:14:03.37759Z",
+                  "eol_date": "2018-04-01T10:00:00Z",
                   "changelog": [
                     {
                       "component": "kubernetes",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12224

In line with https://github.com/giantswarm/apiextensions/pull/539 this PR adds an optional attribute `eol_date` to the getReleases response item schema.