### PR TITLE
Make release status required

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -681,6 +681,7 @@ definitions:
         description: Date and time of the release creation
       active:
         type: boolean
+        x-nullable: false
         description: |
           If true, the version is available for new clusters and cluster
           upgrades. Older versions become unavailable and thus have the

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -671,7 +671,7 @@ definitions:
   # A cluster array item, as return by getClusters
   V4ReleaseListItem:
     type: object
-    required: ["version", "timestamp", "changelog", "components"]
+    required: ["version", "timestamp", "active", "changelog", "components"]
     properties:
       version:
         type: string


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12567

This PR makes the release status required, so it won't be annotated as `omitempty` in the generated `gsclientgen` data structure.