### PR TITLE
Add property for supported K8s versions in the info response

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -76,11 +76,22 @@ definitions:
           datacenter:
             description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
             type: string
-          supported_k8s_version_skews:
-            description: The supported Kubernetes version skews.
+          kubernetes_versions:
+            description: A list of the available Kubernetes versions available, and their EOL dates.
             type: array
             items:
-              type: string
+              type: object
+              required:
+                - minor_version
+                - eol_date
+              properties:
+                minor_version:
+                  description: The version of the Kubernetes release.
+                  type: string
+                eol_date:
+                  description: The date when the release becomes EOL.
+                  type: string
+                  format: date-time
           availability_zones:
             type: object
             description: Number of availability zones which a cluster can be spread across.

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -77,7 +77,7 @@ definitions:
             description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
             type: string
           kubernetes_versions:
-            description: A list of the available Kubernetes versions available, and their EOL dates.
+            description: Information on some kubernetes versions and their end of life dates.
             type: array
             items:
               type: object

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -91,7 +91,7 @@ definitions:
                 eol_date:
                   description: The date when the release becomes EOL.
                   type: string
-                  format: date-time
+                  format: date
           availability_zones:
             type: object
             description: Number of availability zones which a cluster can be spread across.

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -76,6 +76,11 @@ definitions:
           datacenter:
             description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
             type: string
+          supported_k8s_version_skews:
+            description: The supported Kubernetes version skews.
+            type: array
+            items:
+              type: string
           availability_zones:
             type: object
             description: Number of availability zones which a cluster can be spread across.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -234,6 +234,9 @@ paths:
             "installation_name": "shire",
             "provider": "aws",
             "datacenter": "eu-central-1",
+            "supported_k8s_version_skews": [
+                "1.17", "1.18", "1.19"
+            ],
             "availability_zones": {
               "max": 3,
               "default": 1,
@@ -272,6 +275,9 @@ paths:
             "installation_name": "isengard",
             "provider": "kvm",
             "datacenter": "string",
+            "supported_k8s_version_skews": [
+                "1.17", "1.18", "1.19"
+            ],
             "availability_zones": {
               "max": 1,
               "default": 1,
@@ -308,6 +314,9 @@ paths:
                   "installation_name": "shire",
                   "provider": "aws",
                   "datacenter": "eu-central-1",
+                  "supported_k8s_version_skews": [
+                      "1.17", "1.18", "1.19"
+                  ],
                   "availability_zones": {
                     "max": 3,
                     "default": 1,

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -234,8 +234,15 @@ paths:
             "installation_name": "shire",
             "provider": "aws",
             "datacenter": "eu-central-1",
-            "supported_k8s_version_skews": [
-              "1.17", "1.18", "1.19"
+            "kubernetes_versions": [
+              {
+                "minor_version": "1.15",
+                "eol_date": "2020-03-24T00:00:47.215Z"
+              },
+              {
+                "minor_version": "1.16",
+                "eol_date": "2020-08-26T00:00:47.215Z"
+              }
             ],
             "availability_zones": {
               "max": 3,
@@ -275,8 +282,15 @@ paths:
             "installation_name": "isengard",
             "provider": "kvm",
             "datacenter": "string",
-            "supported_k8s_version_skews": [
-              "1.17", "1.18", "1.19"
+            "kubernetes_versions": [
+              {
+                "minor_version": "1.15",
+                "eol_date": "2020-03-24T00:00:47.215Z"
+              },
+              {
+                "minor_version": "1.16",
+                "eol_date": "2020-08-26T00:00:47.215Z"
+              }
             ],
             "availability_zones": {
               "max": 1,
@@ -314,8 +328,15 @@ paths:
                   "installation_name": "shire",
                   "provider": "aws",
                   "datacenter": "eu-central-1",
-                  "supported_k8s_version_skews": [
-                    "1.17", "1.18", "1.19"
+                  "kubernetes_versions": [
+                    {
+                      "minor_version": "1.15",
+                      "eol_date": "2020-03-24T00:00:47.215Z"
+                    },
+                    {
+                      "minor_version": "1.16",
+                      "eol_date": "2020-08-26T00:00:47.215Z"
+                    }
                   ],
                   "availability_zones": {
                     "max": 3,

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -235,7 +235,7 @@ paths:
             "provider": "aws",
             "datacenter": "eu-central-1",
             "supported_k8s_version_skews": [
-                "1.17", "1.18", "1.19"
+              "1.17", "1.18", "1.19"
             ],
             "availability_zones": {
               "max": 3,
@@ -276,7 +276,7 @@ paths:
             "provider": "kvm",
             "datacenter": "string",
             "supported_k8s_version_skews": [
-                "1.17", "1.18", "1.19"
+              "1.17", "1.18", "1.19"
             ],
             "availability_zones": {
               "max": 1,
@@ -315,7 +315,7 @@ paths:
                   "provider": "aws",
                   "datacenter": "eu-central-1",
                   "supported_k8s_version_skews": [
-                      "1.17", "1.18", "1.19"
+                    "1.17", "1.18", "1.19"
                   ],
                   "availability_zones": {
                     "max": 3,

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -237,11 +237,11 @@ paths:
             "kubernetes_versions": [
               {
                 "minor_version": "1.15",
-                "eol_date": "2020-03-24T00:00:47.215Z"
+                "eol_date": "2020-03-24"
               },
               {
                 "minor_version": "1.16",
-                "eol_date": "2020-08-26T00:00:47.215Z"
+                "eol_date": "2020-08-26"
               }
             ],
             "availability_zones": {
@@ -285,11 +285,11 @@ paths:
             "kubernetes_versions": [
               {
                 "minor_version": "1.15",
-                "eol_date": "2020-03-24T00:00:47.215Z"
+                "eol_date": "2020-03-24"
               },
               {
                 "minor_version": "1.16",
-                "eol_date": "2020-08-26T00:00:47.215Z"
+                "eol_date": "2020-08-26"
               }
             ],
             "availability_zones": {
@@ -331,11 +331,11 @@ paths:
                   "kubernetes_versions": [
                     {
                       "minor_version": "1.15",
-                      "eol_date": "2020-03-24T00:00:47.215Z"
+                      "eol_date": "2020-03-24"
                     },
                     {
                       "minor_version": "1.16",
-                      "eol_date": "2020-08-26T00:00:47.215Z"
+                      "eol_date": "2020-08-26"
                     }
                   ],
                   "availability_zones": {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13439

Add new `supported_k8s_version_skews` property in the info response, for displaying the supported K8s versions. Versions older than the ones specified are EOL and should not be used for new clusters.

This PR will be merged once the API implementation is done and released.

