### PR TITLE
Added new fields to the v5/addCluster call to better specify how avai…

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1192,7 +1192,7 @@ definitions:
               This field allows manually specifying the availability zone(s) where the master node(s)
               should be created in.
 
-              This parameter is supported on Azure clusters only.
+              This parameter is currently only supported on <span class="badge azure">Azure</span>.
           azure:
             type: object
             description: |

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -76,6 +76,22 @@ definitions:
           datacenter:
             description: Identifier of the datacenter or cloud provider region, e. g. "eu-west-1"
             type: string
+          kubernetes_versions:
+            description: Information on some kubernetes versions and their end of life dates.
+            type: array
+            items:
+              type: object
+              required:
+                - minor_version
+                - eol_date
+              properties:
+                minor_version:
+                  description: The version of the Kubernetes release.
+                  type: string
+                eol_date:
+                  description: The date when the release becomes EOL.
+                  type: string
+                  format: date
           availability_zones:
             type: object
             description: Number of availability zones which a cluster can be spread across.

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1183,6 +1183,29 @@ definitions:
 
               When `false`, only one master node will be created, also in a randomly
               selected availability zone.
+          availability_zones_selection_mode:
+            type: string
+            default: auto
+            description: |
+              Specifies how the availability zone(s) for the master node(s) should be selected.
+              Possible values are `auto`, `manual` and `disabled`
+
+              When set to `auto` the system will randomly assign an availability zone to each
+              master node.
+
+              When set to `manual` the request needs to contain an additional field `availability_zones`
+              containing the list of desired availability zones the master nodes should be placed in.
+
+              When set to `disabled` the master nodes will not be placed in any availability zone
+              (supported on Azure clusters only).
+          availability_zones:
+            type: array
+            items:
+              type: string
+            description: |
+              When `availability_zones_selection_mode` is set to `manual`, this field becomes
+              mandatory and allow manually specifying the availability zone(s) where the master node(s)
+              should be created in.
   V5ClusterDetailsResponse:
     type: object
     properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1196,7 +1196,7 @@ definitions:
           azure:
             type: object
             description: |
-              Attributes specific to nodes running on Microsoft Azure
+              Attributes specific to nodes running on <span class="badge azure">Azure</span>.
             properties:
               availability_zones_unspecified:
                 type: boolean

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1206,6 +1206,8 @@ definitions:
               When `availability_zones_selection_mode` is set to `manual`, this field becomes
               mandatory and allow manually specifying the availability zone(s) where the master node(s)
               should be created in.
+
+              This parameter is supported on Azure clusters only.
   V5ClusterDetailsResponse:
     type: object
     properties:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1184,31 +1184,25 @@ definitions:
 
               When `false`, only one master node will be created, also in a randomly
               selected availability zone.
-          availability_zones_selection_mode:
-            type: string
-            default: auto
-            description: |
-              Specifies how the availability zone(s) for the master node(s) should be selected.
-              Possible values are `auto`, `manual` and `disabled`
-
-              When set to `auto` the system will randomly assign an availability zone to each
-              master node.
-
-              When set to `manual` the request needs to contain an additional field `availability_zones`
-              containing the list of desired availability zones the master nodes should be placed in.
-
-              When set to `disabled` the master nodes will not be placed in any availability zone
-              (supported on Azure clusters only).
           availability_zones:
             type: array
             items:
               type: string
             description: |
-              When `availability_zones_selection_mode` is set to `manual`, this field becomes
-              mandatory and allow manually specifying the availability zone(s) where the master node(s)
+              This field allows manually specifying the availability zone(s) where the master node(s)
               should be created in.
 
               This parameter is supported on Azure clusters only.
+          azure:
+            type: object
+            description: |
+              Attributes specific to nodes running on Microsoft Azure
+            properties:
+              availability_zones_unspecified:
+                type: boolean
+                description: |
+                  If this field is set to true, the content of the `availability_zones' field will be ignored and
+                  the master nodes will be placed in no availability zone.
   V5ClusterDetailsResponse:
     type: object
     properties:

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -234,6 +234,16 @@ paths:
             "installation_name": "shire",
             "provider": "aws",
             "datacenter": "eu-central-1",
+            "kubernetes_versions": [
+              {
+                "minor_version": "1.15",
+                "eol_date": "2020-03-24"
+              },
+              {
+                "minor_version": "1.16",
+                "eol_date": "2020-08-26"
+              }
+            ],
             "availability_zones": {
               "max": 3,
               "default": 1,
@@ -272,6 +282,16 @@ paths:
             "installation_name": "isengard",
             "provider": "kvm",
             "datacenter": "string",
+            "kubernetes_versions": [
+              {
+                "minor_version": "1.15",
+                "eol_date": "2020-03-24"
+              },
+              {
+                "minor_version": "1.16",
+                "eol_date": "2020-08-26"
+              }
+            ],
             "availability_zones": {
               "max": 1,
               "default": 1,
@@ -308,6 +328,16 @@ paths:
                   "installation_name": "shire",
                   "provider": "aws",
                   "datacenter": "eu-central-1",
+                  "kubernetes_versions": [
+                    {
+                      "minor_version": "1.15",
+                      "eol_date": "2020-03-24"
+                    },
+                    {
+                      "minor_version": "1.16",
+                      "eol_date": "2020-08-26"
+                    }
+                  ],
                   "availability_zones": {
                     "max": 3,
                     "default": 1,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13842

When I am creating a CAPI cluster on Azure I would like to be able to select between 3 modes for assigning availability zones to the master nodes:

- automated: system assigns random availability zones to each master node
- manual: users select availability zones to be used for masters
- none: no availability zones have to be used.

This PR adds the needed, backward compatible fields to make this feature possible.