### PR TITLE
Terminology changes: "tenant cluster" to "workload cluster", "control plane" to "management cluster"

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -337,7 +337,7 @@ definitions:
           $ref: '#/definitions/V4NodeDefinition'
       kvm:
         type: object
-        description: Attributes specific to clusters running on KVM (on-prem) installations.
+        description: Attributes specific to clusters running on KVM (on-premises) installations.
         properties:
           port_mappings:
             type: array

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -342,14 +342,15 @@ definitions:
           port_mappings:
             type: array
             description: |
-              Reveals the ports on the control plane that are mapped to this workload cluster's ingress
-              and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.
+              Reveals the ports on the installation's load balancer that are mapped to this
+              workload cluster's ingress and which protocol that port supports. Only shown
+              and relevant on our on-premises KVM clusters.
             items:
               type: object
               properties:
                 port:
                   description: |
-                    The port on the control plane that will forward traffic to the workload cluster
+                    The port on the management cluster that will forward traffic to the workload cluster
                   type: integer
                 protocol:
                   description: |
@@ -499,7 +500,7 @@ definitions:
             description: Name of the ConfigMap containing user-values to apply, e.g. prometheus-user-values
           namespace:
             type: string
-            description: Namespace of the user-values ConfigMap on the control plane, e.g. 123ab
+            description: Namespace of the user-values ConfigMap on the management cluster, e.g. 123ab
       secret:
         type: object
         properties:
@@ -508,7 +509,7 @@ definitions:
             description: Name of the Secret containing user-secrets to apply, e.g. prometheus-user-secrets
           namespace:
             type: string
-            description: Namespace of the user-secrets Secret on the control plane, e.g. 123ab
+            description: Namespace of the user-secrets Secret on the management cluster, e.g. 123ab
 
   V4GetClusterAppsResponse:
     type: array

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -107,7 +107,7 @@ definitions:
                 type: integer
               zones:
                 type: array
-                description: The availability zones available in the installation's region for use with tenant clusters.
+                description: The availability zones available in the installation's region for use with workload clusters.
                 items:
                   type: string
       features:
@@ -342,14 +342,14 @@ definitions:
           port_mappings:
             type: array
             description: |
-              Reveals the ports on the control plane that are mapped to this tenant cluster's ingress
+              Reveals the ports on the control plane that are mapped to this workload cluster's ingress
               and which protocol that port supports. Only shown and relevant on our on-prem KVM clusters.
             items:
               type: object
               properties:
                 port:
                   description: |
-                    The port on the control plane that will forward traffic to the tenant cluster
+                    The port on the control plane that will forward traffic to the workload cluster
                   type: integer
                 protocol:
                   description: |
@@ -1082,7 +1082,7 @@ definitions:
     type: object
     properties:
       id:
-        description: Node pool identifier. Unique within a tenant cluster.
+        description: Node pool identifier. Unique within a workload cluster.
         type: string
       name:
         description: Node pool name

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -142,7 +142,7 @@ paths:
                           some changes to the security settings of your cluster.
 
           App Catalogs can also be labeled as `internal`, however these catalogs
-          contain apps that run on our control planes. These `internal` app catalogs
+          contain apps that run on our management clusters. These `internal` app catalogs
           will be filtered out and never shown when calling this endpoint.
 
           For more details on app catalogs visit: https://docs.giantswarm.io/basics/app-catalog/
@@ -1435,7 +1435,7 @@ paths:
         ### About the user_config field in the response
         This field is not editable by you, but is set automatically by the API
         if a ConfigMap named `{app_name}-user-values` exists in the workload cluster
-        namespace on the control plane.
+        namespace on the management cluster.
 
         The `/v4/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows
         you to create such a ConfigMap using this API.
@@ -1451,7 +1451,7 @@ paths:
         It simplifies usage while also being a security measure.
 
         Furthermore it is also a security measure and ensures that users of this
-        API can't access arbitrary configmaps of the control plane.
+        API can't access arbitrary configmaps of the management cluster.
 
         This API will only allow you to edit or access configmaps that adhere
         to a strict naming convention.
@@ -2296,7 +2296,7 @@ paths:
         ### About the user_config field in the response
         This field is not editable by you, but is set automatically by the API
         if a ConfigMap named `{app_name}-user-values` exists in the workload cluster
-        namespace on the control plane.
+        namespace on the management cluster.
 
         The `/v5/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows
         you to create such a ConfigMap using this API.
@@ -2312,7 +2312,7 @@ paths:
         It simplifies usage while also being a security measure.
 
         Furthermore it is also a security measure and ensures that users of this
-        API can't access arbitrary configmaps of the control plane.
+        API can't access arbitrary configmaps of the management cluster.
 
         This API will only allow you to edit or access configmaps that adhere
         to a strict naming convention.

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -20,7 +20,7 @@ info:
 
     ## Versioning
 
-    Some endpoint paths are different, depending on the release version of the tenant cluster that they expect. All V5 endpoints except a cluster release version newer than `10.0.0` on  <span class="badge aws">AWS</span>, or `13.0.0` on <span class="badge azure">Azure</span>. Cluster release versions older than that, or on different providers, must be used with V4 endpoints.
+    Some endpoint paths are different, depending on the release version of the workload cluster that they expect. All V5 endpoints except a cluster release version newer than `10.0.0` on  <span class="badge aws">AWS</span>, or `13.0.0` on <span class="badge azure">Azure</span>. Cluster release versions older than that, or on different providers, must be used with V4 endpoints.
     If there is no V5 endpoint for a specific command (e.g. `Get clusters`), then release version rules don't apply, and the V4 endpoint must be used.
 
   termsOfService: https://giantswarm.io/terms/
@@ -49,7 +49,7 @@ tags:
     description: |
       Cluster labels allow users to group and tag clusters with custom key-value-pairs.
 
-      Note: Cluster labelling is currently only available on tenant cluster release version 10 or higher on <span class="badge aws">AWS</span>, and tenant cluster release version 13 or higher on <span class="badge azure">Azure</span>.
+      Note: Cluster labelling is currently only available on workload cluster release version 10 or higher on <span class="badge aws">AWS</span>, and workload cluster release version 13 or higher on <span class="badge azure">Azure</span>.
   - name: info
     description: Information about the Giant Swarm installation
   - name: key pairs
@@ -67,7 +67,7 @@ tags:
       level. This allows to fulfill a variety of different workload requirements
       within the same cluster.
   - name: apps
-    description: "An app is a helm chart that you can easily install on your tenant clusters. Use these endpoints to: find out what catalogs your installation supports, and list and install apps on on your tenant clusters."
+    description: "An app is a helm chart that you can easily install on your workload clusters. Use these endpoints to: find out what catalogs your installation supports, and list and install apps on on your workload clusters."
   - name: app configs
     description: "Creating an app config lets you supply your apps with custom configuration values."
   - name: app secrets
@@ -805,7 +805,7 @@ paths:
       summary: Create cluster (v4)
       description: |
         This operation is used to create a new Kubernetes cluster or
-        "tenant cluster".
+        "workload cluster".
 
         ### Cluster definition
 
@@ -1170,7 +1170,7 @@ paths:
 
         In addition to the credentials itself, a key pair has some metadata like a unique ID, a creation timestamp and a free text `description` that you can use at will, for example to note for whom a key pair has been issued.
 
-        After creation of a tenant cluster, it might take a couple of seconds before this operation can be performed successfully. In this case, the API will respond with code 503, indicating that you should retry the call after some wait time.
+        After creation of a workload cluster, it might take a couple of seconds before this operation can be performed successfully. In this case, the API will respond with code 503, indicating that you should retry the call after some wait time.
 
         ### Customizing the certificate's subject for K8s RBAC
 
@@ -1402,7 +1402,7 @@ paths:
         - apps
       summary: Install an app (v4)
       description: |
-        Install an app on a tenant cluster by using this endpoint.
+        Install an app on a workload cluster by using this endpoint.
         For apps on v5 clusters, please use the v5 version of this endpoint.
 
         The spec field represents the app we'll be installing, and so spec.name refers to
@@ -1434,7 +1434,7 @@ paths:
 
         ### About the user_config field in the response
         This field is not editable by you, but is set automatically by the API
-        if a ConfigMap named `{app_name}-user-values` exists in the tenant cluster
+        if a ConfigMap named `{app_name}-user-values` exists in the workload cluster
         namespace on the control plane.
 
         The `/v4/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows
@@ -2264,7 +2264,7 @@ paths:
         - apps
       summary: Install an app (v5)
       description: |
-        Install an app on a tenant cluster by using this endpoint.
+        Install an app on a workload cluster by using this endpoint.
 
         The spec field represents the app we'll be installing, and so spec.name refers to
         the name of the app in the catalog.
@@ -2295,7 +2295,7 @@ paths:
 
         ### About the user_config field in the response
         This field is not editable by you, but is set automatically by the API
-        if a ConfigMap named `{app_name}-user-values` exists in the tenant cluster
+        if a ConfigMap named `{app_name}-user-values` exists in the workload cluster
         namespace on the control plane.
 
         The `/v5/clusters/{cluster_id}/apps/{app_name}/config/` endpoints allows


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14961
