### PR TITLE
Add properties regarding azure spot instances

### DIFF
--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1032,11 +1032,11 @@ definitions:
               max_price:
                 description: |
                   The maximum price that a single node pool VM instance can reach before it is deallocated.
-                  By setting this value to `-1`, the maximum price will be fixed to the on-demand price of
+                  By setting this value to `0`, the maximum price will be fixed to the on-demand price of
                   the instance.
                   The value can be a floating point number with a maximum of 5 decimal places.
                 type: number
-                default: -1
+                default: 0
 
   # Specification of a node in a node pool after creation
   V5GetNodePoolResponseNodeSpec:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1031,7 +1031,7 @@ definitions:
                 default: false
               max_price:
                 description: |
-                  The maximum price that a single node pool VM instance can reach before it is deallocated.
+                  The maximum price in USD that a single node pool VM instance can reach before it is deallocated.
                   By setting this value to `0`, the maximum price will be fixed to the on-demand price of
                   the instance.
                   The value can be a floating point number with a maximum of 5 decimal places.

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1031,9 +1031,9 @@ definitions:
                 default: false
               max_price:
                 description: |
-                  The maximum price that the node pool VM Size can reach before the node pool is deallocated.
-                  By setting this value to `-1`, the price will be fixed to the value it had when the
-                  node pool was created. The node pool will not be deallocated for pricing reasons.
+                  The maximum price that a single node pool VM instance can reach before it is deallocated.
+                  By setting this value to `-1`, the maximum price will be fixed to the on-demand price of
+                  the instance.
                   The value can be a floating point number with a maximum of 5 decimal places.
                 type: number
                 default: -1

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1019,6 +1019,24 @@ definitions:
             type: string
             description: |
               Azure VM size to use for all nodes in the node pool. _(Validated against available VM sizes.)_
+          spot_instances:
+            description: |
+              Attributes defining the presence and configuration of Spot Instances.
+            type: object
+            properties:
+              enabled:
+                description: |
+                  Whether the feature is enabled or not.
+                type: boolean
+                default: false
+              max_price:
+                description: |
+                  The maximum price that the node pool VM Size can reach before the node pool is deallocated.
+                  By setting this value to `-1`, the price will be fixed to the value it had when the
+                  node pool was created. The node pool will not be deallocated for pricing reasons.
+                  The value can be a floating point number with a maximum of 5 decimal places.
+                type: number
+                default: -1
 
   # Specification of a node in a node pool after creation
   V5GetNodePoolResponseNodeSpec:
@@ -1034,6 +1052,20 @@ definitions:
             type: string
             description: |
               Azure virtual machine size used by all nodes in this pool.
+          spot_instances:
+            description: |
+              Attributes defining the presence and configuration of Spot Instances.
+            type: object
+            properties:
+              enabled:
+                description: |
+                  Whether the feature is enabled or not.
+                type: boolean
+              max_price:
+                description: |
+                  The maximum price that the node pool VM Size can reach before the node pool is deallocated.
+                  Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
+                type: number
       aws:
         type: object
         x-nullable: true

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1063,7 +1063,7 @@ definitions:
                 type: boolean
               max_price:
                 description: |
-                  The maximum price that the node pool VM Size can reach before the node pool is deallocated.
+                  The maximum price that a single node pool VM instance can reach before it is deallocated.
                   Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
                 type: number
       aws:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1064,7 +1064,7 @@ definitions:
                 type: boolean
               max_price:
                 description: |
-                  The maximum price that a single node pool VM instance can reach before it is deallocated.
+                  The maximum price in USD that a single node pool VM instance can reach before it is deallocated.
                   Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
                 type: number
       aws:

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1031,7 +1031,7 @@ definitions:
                 default: false
               max_price:
                 description: |
-                  The maximum price in USD that a single node pool VM instance can reach before it is deallocated.
+                  The maximum price per hour (in USD) that a single node pool VM instance can reach before it is deallocated.
                   By setting this value to `0`, the maximum price will be fixed to the on-demand price of
                   the instance.
                   The value can be a floating point number with a maximum of 5 decimal places.
@@ -1064,7 +1064,7 @@ definitions:
                 type: boolean
               max_price:
                 description: |
-                  The maximum price in USD that a single node pool VM instance can reach before it is deallocated.
+                  The maximum price per hour (in USD) that a single node pool VM instance can reach before it is deallocated.
                   Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
                 type: number
                 format: float

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1036,6 +1036,7 @@ definitions:
                   the instance.
                   The value can be a floating point number with a maximum of 5 decimal places.
                 type: number
+                format: float
                 default: 0
 
   # Specification of a node in a node pool after creation

--- a/spec/definitions.yaml
+++ b/spec/definitions.yaml
@@ -1067,6 +1067,7 @@ definitions:
                   The maximum price in USD that a single node pool VM instance can reach before it is deallocated.
                   Find details on this attribute in the [addNodePool](#operation/addNodePool) operation.
                 type: number
+                format: float
       aws:
         type: object
         x-nullable: true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15310

This PR adds configuration settings for Azure Spot Instances:
* Node pool creation:
	* Enabling or disabling the feature
	* Setting a maximum price for deallocating the node pool (or disabling deallocating based on pricing reasons)
* Node pool listing/searching:
	* Seeing if the feature is enabled or not
	* Seeing the maximum price for deallocating the node pool (or the lack of it)