### PR TITLE
Update catalog domain to github.io and update architect-orb to 2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.1.0
+  architect: giantswarm/architect@2.7.0
 
 jobs:
   build:

--- a/helm/api-spec-app/Chart.yaml
+++ b/helm/api-spec-app/Chart.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 name: api-spec-app
-namespace: docs
 appVersion: 0.0.1
 description: Serves the ReDoc container with the documentation of the GS API.
 home: https://github.com/giantswarm/api-spec

--- a/spec/spec.yaml
+++ b/spec/spec.yaml
@@ -162,7 +162,7 @@ paths:
                 "logoURL": "https://s.giantswarm.io/app-catalog/1/images/sample-catalog.png",
 
                 "storage": {
-                  "URL": "https://giantswarm.github.com/sample-catalog/",
+                  "URL": "https://giantswarm.github.io/sample-catalog/",
                   "type": "helm"
                 },
                 "title": "Sample Catalog"
@@ -196,7 +196,7 @@ paths:
                     "logoURL": "https://s.giantswarm.io/app-catalog/1/images/sample-catalog.png",
 
                     "storage": {
-                      "URL": "https://giantswarm.github.com/sample-catalog/",
+                      "URL": "https://giantswarm.github.io/sample-catalog/",
                       "type": "helm"
                     },
                     "title": "Sample Catalog"


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898

Also updates the architect-orb version to 2.7.0 to resolve pushing into catalogs