### PR TITLE
CircleCI: also lint on tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
 workflows:
   build-workflow:
     jobs:
-      - lint
+      - lint:
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ workflows:
   build-workflow:
     jobs:
       - lint
+          filters:
+            tags:
+              only: /^v.*/
       - architect/push-to-registries:
           name: push-to-registries
           context: architect


### PR DESCRIPTION
The goal of this PR is to make sure that the workflow also runs on tagged releases.